### PR TITLE
Implemented Codspeed testing and no_std functionality

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,13 +1,14 @@
+on: [push, pull_request]
 name: CodSpeed
 
-on:
-    push:
-        branches:
-            - 'master'
-    pull_request:
-    # `workflow_dispatch` allows CodSpeed to trigger backtest
-    # performance analysis in order to generate initial data.
-    workflow_dispatch:
+# on:
+#     push:
+#         branches:
+#             - 'master'
+#     pull_request:
+#     # `workflow_dispatch` allows CodSpeed to trigger backtest
+#     # performance analysis in order to generate initial data.
+#     workflow_dispatch:
 
 jobs:
     benchmarks:

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -28,7 +28,7 @@ jobs:
                   token: ${{ secrets.CODSPEED }}
 
     benchmark-nightly:
-        name: Run benchmarks
+        name: Run Nightly Benchmarks
         runs-on: ubuntu-latest
         env:
             RUSTFLAGS: '-Ctarget-cpu=native'

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -3,32 +3,8 @@ on: [push, pull_request]
 name: CodSpeed
 
 jobs:
-    benchmark-stable:
-        name: Run Stable Benchmarks
-        runs-on: ubuntu-latest
-        env:
-            RUSTFLAGS: '-Ctarget-cpu=native'
-        steps:
-            - uses: actions/checkout@v4
-
-            - name: Setup rust toolchain, cache and cargo-codspeed binary
-              uses: moonrepo/setup-rust@v1
-              with:
-                  channel: stable
-                  cache-target: release
-                  bins: cargo-codspeed
-
-            - name: Build the benchmark target(s)
-              run: cargo codspeed build
-
-            - name: Run the benchmarks
-              uses: CodSpeedHQ/action@v3
-              with:
-                  run: cargo codspeed run
-                  token: ${{ secrets.CODSPEED }}
-
-    benchmark-nightly:
-        name: Run Nightly Benchmarks
+    benchmarks:
+        name: Run benchmarks
         runs-on: ubuntu-latest
         env:
             RUSTFLAGS: '-Ctarget-cpu=native'
@@ -41,6 +17,15 @@ jobs:
                   channel: nightly
                   cache-target: release
                   bins: cargo-codspeed
+
+            - name: Build the benchmark target(s)
+              run: cargo codspeed build
+
+            - name: Run the benchmarks
+              uses: CodSpeedHQ/action@v3
+              with:
+                  run: cargo codspeed run
+                  token: ${{ secrets.CODSPEED }}
 
             - name: Build the benchmark target(s)
               run: cargo codspeed build --features nightly

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -3,7 +3,31 @@ on: [push, pull_request]
 name: CodSpeed
 
 jobs:
-    benchmarks:
+    benchmark-stable:
+        name: Run Stable Benchmarks
+        runs-on: ubuntu-latest
+        env:
+            RUSTFLAGS: '-Ctarget-cpu=native'
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Setup rust toolchain, cache and cargo-codspeed binary
+              uses: moonrepo/setup-rust@v1
+              with:
+                  channel: stable
+                  cache-target: release
+                  bins: cargo-codspeed
+
+            - name: Build the benchmark target(s)
+              run: cargo codspeed build
+
+            - name: Run the benchmarks
+              uses: CodSpeedHQ/action@v3
+              with:
+                  run: cargo codspeed run
+                  token: ${{ secrets.CODSPEED }}
+
+    benchmark-nightly:
         name: Run benchmarks
         runs-on: ubuntu-latest
         env:
@@ -17,15 +41,6 @@ jobs:
                   channel: nightly
                   cache-target: release
                   bins: cargo-codspeed
-
-            - name: Build the benchmark target(s)
-              run: cargo codspeed build
-
-            - name: Run the benchmarks
-              uses: CodSpeedHQ/action@v3
-              with:
-                  run: cargo codspeed run
-                  token: ${{ secrets.CODSPEED }}
 
             - name: Build the benchmark target(s)
               run: cargo codspeed build --features nightly

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -26,3 +26,12 @@ jobs:
               with:
                   run: cargo codspeed run
                   token: ${{ secrets.CODSPEED }}
+
+            - name: Build the benchmark target(s)
+              run: cargo codspeed build --features nightly
+
+            - name: Run the benchmarks
+              uses: CodSpeedHQ/action@v3
+              with:
+                  run: cargo codspeed run
+                  token: ${{ secrets.CODSPEED }}

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,0 +1,35 @@
+name: CodSpeed
+
+on:
+    push:
+        branches:
+            - 'master'
+    pull_request:
+    # `workflow_dispatch` allows CodSpeed to trigger backtest
+    # performance analysis in order to generate initial data.
+    workflow_dispatch:
+
+jobs:
+    benchmarks:
+        name: Run benchmarks
+        runs-on: ubuntu-latest
+        env:
+            RUSTFLAGS: '-Ctarget-cpu=native'
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Setup rust toolchain, cache and cargo-codspeed binary
+              uses: moonrepo/setup-rust@v1
+              with:
+                  channel: nightly
+                  cache-target: release
+                  bins: cargo-codspeed
+
+            - name: Build the benchmark target(s)
+              run: cargo codspeed build
+
+            - name: Run the benchmarks
+              uses: CodSpeedHQ/action@v3
+              with:
+                  run: cargo codspeed run
+                  token: ${{ secrets.CODSPEED }}

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,14 +1,6 @@
 on: [push, pull_request]
-name: CodSpeed
 
-# on:
-#     push:
-#         branches:
-#             - 'master'
-#     pull_request:
-#     # `workflow_dispatch` allows CodSpeed to trigger backtest
-#     # performance analysis in order to generate initial data.
-#     workflow_dispatch:
+name: CodSpeed
 
 jobs:
     benchmarks:

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -11,7 +11,7 @@ jobs:
             - uses: actions-rs/toolchain@v1
               with:
                   profile: minimal
-                  toolchain: stable
+                  toolchain: nightly
                   override: true
             - uses: actions-rs/cargo@v1
               with:
@@ -25,7 +25,7 @@ jobs:
             - uses: actions-rs/toolchain@v1
               with:
                   profile: minimal
-                  toolchain: stable
+                  toolchain: nightly
                   override: true
             - uses: actions-rs/cargo@v1
               with:
@@ -39,7 +39,7 @@ jobs:
             - uses: actions-rs/toolchain@v1
               with:
                   profile: minimal
-                  toolchain: stable
+                  toolchain: nightly
                   override: true
             - run: rustup component add rustfmt
             - uses: actions-rs/cargo@v1
@@ -55,7 +55,7 @@ jobs:
             - uses: actions-rs/toolchain@v1
               with:
                   profile: minimal
-                  toolchain: stable
+                  toolchain: nightly
                   override: true
             - run: rustup component add clippy
             - uses: actions-rs/cargo@v1

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -3,8 +3,21 @@ on: [push, pull_request]
 name: Continuous integration
 
 jobs:
-    check:
-        name: Check
+    check-stable:
+        name: Stable Check
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions-rs/toolchain@v1
+              with:
+                  profile: minimal
+                  toolchain: stable
+                  override: true
+            - uses: actions-rs/cargo@v1
+              with:
+                  command: check
+    check-nightly:
+        name: Nightly Check
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
@@ -16,7 +29,7 @@ jobs:
             - uses: actions-rs/cargo@v1
               with:
                   command: check
-
+                  args: --features nightly
     test-stable:
         name: Stable Test Suite
         runs-on: ubuntu-latest
@@ -25,7 +38,7 @@ jobs:
             - uses: actions-rs/toolchain@v1
               with:
                   profile: minimal
-                  toolchain: nightly
+                  toolchain: stable
                   override: true
             - uses: actions-rs/cargo@v1
               with:
@@ -61,8 +74,23 @@ jobs:
                   command: fmt
                   args: --all -- --check
 
-    clippy:
-        name: Clippy
+    clippy-stable:
+        name: Stable Clippy
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions-rs/toolchain@v1
+              with:
+                  profile: minimal
+                  toolchain: stable
+                  override: true
+            - run: rustup component add clippy
+            - uses: actions-rs/cargo@v1
+              with:
+                  command: clippy
+                  args: -- -D warnings
+    clippy-nightly:
+        name: Nightly Clippy
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
@@ -75,4 +103,4 @@ jobs:
             - uses: actions-rs/cargo@v1
               with:
                   command: clippy
-                  args: -- -D warnings
+                  args: --features nightly -- -D warnings

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -17,8 +17,21 @@ jobs:
               with:
                   command: check
 
-    test:
-        name: Test Suite
+    test-stable:
+        name: Stable Test Suite
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions-rs/toolchain@v1
+              with:
+                  profile: minimal
+                  toolchain: stable
+                  override: true
+            - uses: actions-rs/cargo@v1
+              with:
+                  command: test
+    test-nightly:
+        name: Nightly Test Suite
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
@@ -30,6 +43,7 @@ jobs:
             - uses: actions-rs/cargo@v1
               with:
                   command: test
+                  args: --features nightly
 
     fmt:
         name: Rustfmt
@@ -39,7 +53,7 @@ jobs:
             - uses: actions-rs/toolchain@v1
               with:
                   profile: minimal
-                  toolchain: nightly
+                  toolchain: stable
                   override: true
             - run: rustup component add rustfmt
             - uses: actions-rs/cargo@v1

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -25,7 +25,7 @@ jobs:
             - uses: actions-rs/toolchain@v1
               with:
                   profile: minimal
-                  toolchain: stable
+                  toolchain: nightly
                   override: true
             - uses: actions-rs/cargo@v1
               with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,14 @@ license = "MIT"
 float-cmp = "0.10.0"
 criterion = { version = "3.0.4", package = "codspeed-criterion-compat" }
 
-[dependencies]
-intrinsics = "0.1.0"
+[features]
+alloc = []
+std = ["intrinsics"]
+default = ["std"]
+
+[dependencies.intrinsics]
+version = "0.1.0"
+optional = true
 
 [lib]
 name = "rust_steam"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ license = "MIT"
 float-cmp = "0.10.0"
 criterion = { version = "3.0.4", package = "codspeed-criterion-compat" }
 
+[dependencies]
+intrinsics = "0.1.0"
+
 [lib]
 name = "rust_steam"
 path = "src/iapws97.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,11 @@ license = "MIT"
 
 [dev-dependencies]
 float-cmp = "0.10.0"
-criterion = { version = "3.0.4", package = "codspeed-criterion-compat" }
+criterion = { version = "3.0.5", package = "codspeed-criterion-compat" }
 
 [features]
-alloc = []
-std = ["intrinsics"]
+std = []
+nightly = []
 default = ["std"]
 
 [dependencies.intrinsics]

--- a/benches/region1.rs
+++ b/benches/region1.rs
@@ -2,122 +2,241 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rust_steam::iapws97;
 
 pub fn criterion_benchmark(c: &mut Criterion) {
-    // Region 1 hmass_tp
-    c.bench_function("Region 1 hmass_tp-1", |b| {
-        b.iter(|| iapws97::hmass_tp(black_box(300.0), black_box(3e6)))
-    });
+    if cfg!(feature = "nightly") {
+        // Region 1 hmass_tp
+        c.bench_function("SIMD Region 1 hmass_tp-1", |b| {
+            b.iter(|| iapws97::hmass_tp(black_box(300.0), black_box(3e6)))
+        });
 
-    c.bench_function("Region 1 hmass_tp-2", |b| {
-        b.iter(|| iapws97::hmass_tp(black_box(300.0), black_box(80e6)))
-    });
+        c.bench_function("SIMD Region 1 hmass_tp-2", |b| {
+            b.iter(|| iapws97::hmass_tp(black_box(300.0), black_box(80e6)))
+        });
 
-    c.bench_function("Region 1 hmass_tp-3", |b| {
-        b.iter(|| iapws97::hmass_tp(black_box(500.0), black_box(3e6)))
-    });
+        c.bench_function("SIMD Region 1 hmass_tp-3", |b| {
+            b.iter(|| iapws97::hmass_tp(black_box(500.0), black_box(3e6)))
+        });
 
-    // Region 1 umass_tp
-    c.bench_function("Region 1 umass_tp-1", |b| {
-        b.iter(|| iapws97::umass_tp(black_box(300.0), black_box(3e6)))
-    });
+        // Region 1 umass_tp
+        c.bench_function("SIMD Region 1 umass_tp-1", |b| {
+            b.iter(|| iapws97::umass_tp(black_box(300.0), black_box(3e6)))
+        });
 
-    c.bench_function("Region 1 umass_tp-2", |b| {
-        b.iter(|| iapws97::umass_tp(black_box(300.0), black_box(80e6)))
-    });
+        c.bench_function("SIMD Region 1 umass_tp-2", |b| {
+            b.iter(|| iapws97::umass_tp(black_box(300.0), black_box(80e6)))
+        });
 
-    c.bench_function("Region 1 umass_tp-3", |b| {
-        b.iter(|| iapws97::hmass_tp(black_box(500.0), black_box(3e6)))
-    });
+        c.bench_function("SIMD Region 1 umass_tp-3", |b| {
+            b.iter(|| iapws97::hmass_tp(black_box(500.0), black_box(3e6)))
+        });
 
-    // Region 1 smass_tp
-    c.bench_function("Region 1 smass_tp-1", |b| {
-        b.iter(|| iapws97::smass_tp(black_box(300.0), black_box(3e6)))
-    });
+        // Region 1 smass_tp
+        c.bench_function("SIMD Region 1 smass_tp-1", |b| {
+            b.iter(|| iapws97::smass_tp(black_box(300.0), black_box(3e6)))
+        });
 
-    c.bench_function("Region 1 smass_tp-2", |b| {
-        b.iter(|| iapws97::smass_tp(black_box(300.0), black_box(80e6)))
-    });
+        c.bench_function("SIMD Region 1 smass_tp-2", |b| {
+            b.iter(|| iapws97::smass_tp(black_box(300.0), black_box(80e6)))
+        });
 
-    c.bench_function("Region 1 smass_tp-3", |b| {
-        b.iter(|| iapws97::smass_tp(black_box(500.0), black_box(3e6)))
-    });
+        c.bench_function("SIMD Region 1 smass_tp-3", |b| {
+            b.iter(|| iapws97::smass_tp(black_box(500.0), black_box(3e6)))
+        });
 
-    // Region 1 cpmass_tp
-    c.bench_function("Region 1 cpmass_tp-1", |b| {
-        b.iter(|| iapws97::cpmass_tp(black_box(300.0), black_box(3e6)))
-    });
+        // Region 1 cpmass_tp
+        c.bench_function("SIMD Region 1 cpmass_tp-1", |b| {
+            b.iter(|| iapws97::cpmass_tp(black_box(300.0), black_box(3e6)))
+        });
 
-    c.bench_function("Region 1 cpmass_tp-2", |b| {
-        b.iter(|| iapws97::cpmass_tp(black_box(300.0), black_box(80e6)))
-    });
+        c.bench_function("SIMD Region 1 cpmass_tp-2", |b| {
+            b.iter(|| iapws97::cpmass_tp(black_box(300.0), black_box(80e6)))
+        });
 
-    c.bench_function("Region 1 cpmass_tp-3", |b| {
-        b.iter(|| iapws97::cpmass_tp(black_box(500.0), black_box(3e6)))
-    });
+        c.bench_function("SIMD Region 1 cpmass_tp-3", |b| {
+            b.iter(|| iapws97::cpmass_tp(black_box(500.0), black_box(3e6)))
+        });
 
-    // Region 1 cvmass_tp
-    c.bench_function("Region 1 cvmass_tp-1", |b| {
-        b.iter(|| iapws97::cvmass_tp(black_box(300.0), black_box(3e6)))
-    });
+        // Region 1 cvmass_tp
+        c.bench_function("SIMD Region 1 cvmass_tp-1", |b| {
+            b.iter(|| iapws97::cvmass_tp(black_box(300.0), black_box(3e6)))
+        });
 
-    c.bench_function("Region 1 cvmass_tp-2", |b| {
-        b.iter(|| iapws97::cvmass_tp(black_box(300.0), black_box(80e6)))
-    });
+        c.bench_function("SIMD Region 1 cvmass_tp-2", |b| {
+            b.iter(|| iapws97::cvmass_tp(black_box(300.0), black_box(80e6)))
+        });
 
-    c.bench_function("Region 1 cvmass_tp-3", |b| {
-        b.iter(|| iapws97::cvmass_tp(black_box(500.0), black_box(3e6)))
-    });
+        c.bench_function("SIMD Region 1 cvmass_tp-3", |b| {
+            b.iter(|| iapws97::cvmass_tp(black_box(500.0), black_box(3e6)))
+        });
 
-    // Region 1 vmass_tp
-    c.bench_function("Region 1 vmass_tp-1", |b| {
-        b.iter(|| iapws97::vmass_tp(black_box(300.0), black_box(3e6)))
-    });
+        // Region 1 vmass_tp
+        c.bench_function("SIMD Region 1 vmass_tp-1", |b| {
+            b.iter(|| iapws97::vmass_tp(black_box(300.0), black_box(3e6)))
+        });
 
-    c.bench_function("Region 1 vmass_tp-2", |b| {
-        b.iter(|| iapws97::vmass_tp(black_box(300.0), black_box(80e6)))
-    });
+        c.bench_function("SIMD Region 1 vmass_tp-2", |b| {
+            b.iter(|| iapws97::vmass_tp(black_box(300.0), black_box(80e6)))
+        });
 
-    c.bench_function("Region 1 vmass_tp-3", |b| {
-        b.iter(|| iapws97::vmass_tp(black_box(500.0), black_box(3e6)))
-    });
+        c.bench_function("SIMD Region 1 vmass_tp-3", |b| {
+            b.iter(|| iapws97::vmass_tp(black_box(500.0), black_box(3e6)))
+        });
 
-    // Region 1 speed_sound_tp
-    c.bench_function("Region 1 speed_sound_tp-1", |b| {
-        b.iter(|| iapws97::speed_sound_tp(black_box(300.0), black_box(3e6)))
-    });
+        // Region 1 speed_sound_tp
+        c.bench_function("SIMD Region 1 speed_sound_tp-1", |b| {
+            b.iter(|| iapws97::speed_sound_tp(black_box(300.0), black_box(3e6)))
+        });
 
-    c.bench_function("Region 1 speed_sound_tp-2", |b| {
-        b.iter(|| iapws97::speed_sound_tp(black_box(300.0), black_box(80e6)))
-    });
+        c.bench_function("SIMD Region 1 speed_sound_tp-2", |b| {
+            b.iter(|| iapws97::speed_sound_tp(black_box(300.0), black_box(80e6)))
+        });
 
-    c.bench_function("Region 1 speed_sound_tp-3", |b| {
-        b.iter(|| iapws97::speed_sound_tp(black_box(500.0), black_box(3e6)))
-    });
+        c.bench_function("SIMD Region 1 speed_sound_tp-3", |b| {
+            b.iter(|| iapws97::speed_sound_tp(black_box(500.0), black_box(3e6)))
+        });
 
-    // Region 1 temperature_ps
-    c.bench_function("Region 1 temperature_ps-1", |b| {
-        b.iter(|| iapws97::temperature_ps(black_box(3e6), black_box(0.5)))
-    });
+        // Region 1 temperature_ps
+        c.bench_function("SIMD Region 1 temperature_ps-1", |b| {
+            b.iter(|| iapws97::temperature_ps(black_box(3e6), black_box(0.5)))
+        });
 
-    c.bench_function("Region 1 temperature_ps-2", |b| {
-        b.iter(|| iapws97::temperature_ps(black_box(80e6), black_box(0.5)))
-    });
+        c.bench_function("SIMD Region 1 temperature_ps-2", |b| {
+            b.iter(|| iapws97::temperature_ps(black_box(80e6), black_box(0.5)))
+        });
 
-    c.bench_function("Region 1 temperature_ps-3", |b| {
-        b.iter(|| iapws97::temperature_ps(black_box(80e6), black_box(3.0)))
-    });
+        c.bench_function("SIMD Region 1 temperature_ps-3", |b| {
+            b.iter(|| iapws97::temperature_ps(black_box(80e6), black_box(3.0)))
+        });
 
-    // Region 1 temperature_ph
-    c.bench_function("Region 1 temperature_ph-1", |b| {
-        b.iter(|| iapws97::temperature_ph(black_box(3e6), black_box(500.0)))
-    });
+        // Region 1 temperature_ph
+        c.bench_function("SIMD Region 1 temperature_ph-1", |b| {
+            b.iter(|| iapws97::temperature_ph(black_box(3e6), black_box(500.0)))
+        });
 
-    c.bench_function("Region 1 temperature_ph-2", |b| {
-        b.iter(|| iapws97::temperature_ph(black_box(80e6), black_box(500.0)))
-    });
+        c.bench_function("SIMD Region 1 temperature_ph-2", |b| {
+            b.iter(|| iapws97::temperature_ph(black_box(80e6), black_box(500.0)))
+        });
 
-    c.bench_function("Region 1 temperature_ph-3", |b| {
-        b.iter(|| iapws97::temperature_ph(black_box(80e6), black_box(1500.0)))
-    });
+        c.bench_function("SIMD Region 1 temperature_ph-3", |b| {
+            b.iter(|| iapws97::temperature_ph(black_box(80e6), black_box(1500.0)))
+        });
+    } else {
+        // Region 1 hmass_tp
+        c.bench_function("Region 1 hmass_tp-1", |b| {
+            b.iter(|| iapws97::hmass_tp(black_box(300.0), black_box(3e6)))
+        });
+
+        c.bench_function("Region 1 hmass_tp-2", |b| {
+            b.iter(|| iapws97::hmass_tp(black_box(300.0), black_box(80e6)))
+        });
+
+        c.bench_function("Region 1 hmass_tp-3", |b| {
+            b.iter(|| iapws97::hmass_tp(black_box(500.0), black_box(3e6)))
+        });
+
+        // Region 1 umass_tp
+        c.bench_function("Region 1 umass_tp-1", |b| {
+            b.iter(|| iapws97::umass_tp(black_box(300.0), black_box(3e6)))
+        });
+
+        c.bench_function("Region 1 umass_tp-2", |b| {
+            b.iter(|| iapws97::umass_tp(black_box(300.0), black_box(80e6)))
+        });
+
+        c.bench_function("Region 1 umass_tp-3", |b| {
+            b.iter(|| iapws97::hmass_tp(black_box(500.0), black_box(3e6)))
+        });
+
+        // Region 1 smass_tp
+        c.bench_function("Region 1 smass_tp-1", |b| {
+            b.iter(|| iapws97::smass_tp(black_box(300.0), black_box(3e6)))
+        });
+
+        c.bench_function("Region 1 smass_tp-2", |b| {
+            b.iter(|| iapws97::smass_tp(black_box(300.0), black_box(80e6)))
+        });
+
+        c.bench_function("Region 1 smass_tp-3", |b| {
+            b.iter(|| iapws97::smass_tp(black_box(500.0), black_box(3e6)))
+        });
+
+        // Region 1 cpmass_tp
+        c.bench_function("Region 1 cpmass_tp-1", |b| {
+            b.iter(|| iapws97::cpmass_tp(black_box(300.0), black_box(3e6)))
+        });
+
+        c.bench_function("Region 1 cpmass_tp-2", |b| {
+            b.iter(|| iapws97::cpmass_tp(black_box(300.0), black_box(80e6)))
+        });
+
+        c.bench_function("Region 1 cpmass_tp-3", |b| {
+            b.iter(|| iapws97::cpmass_tp(black_box(500.0), black_box(3e6)))
+        });
+
+        // Region 1 cvmass_tp
+        c.bench_function("Region 1 cvmass_tp-1", |b| {
+            b.iter(|| iapws97::cvmass_tp(black_box(300.0), black_box(3e6)))
+        });
+
+        c.bench_function("Region 1 cvmass_tp-2", |b| {
+            b.iter(|| iapws97::cvmass_tp(black_box(300.0), black_box(80e6)))
+        });
+
+        c.bench_function("Region 1 cvmass_tp-3", |b| {
+            b.iter(|| iapws97::cvmass_tp(black_box(500.0), black_box(3e6)))
+        });
+
+        // Region 1 vmass_tp
+        c.bench_function("Region 1 vmass_tp-1", |b| {
+            b.iter(|| iapws97::vmass_tp(black_box(300.0), black_box(3e6)))
+        });
+
+        c.bench_function("Region 1 vmass_tp-2", |b| {
+            b.iter(|| iapws97::vmass_tp(black_box(300.0), black_box(80e6)))
+        });
+
+        c.bench_function("Region 1 vmass_tp-3", |b| {
+            b.iter(|| iapws97::vmass_tp(black_box(500.0), black_box(3e6)))
+        });
+
+        // Region 1 speed_sound_tp
+        c.bench_function("Region 1 speed_sound_tp-1", |b| {
+            b.iter(|| iapws97::speed_sound_tp(black_box(300.0), black_box(3e6)))
+        });
+
+        c.bench_function("Region 1 speed_sound_tp-2", |b| {
+            b.iter(|| iapws97::speed_sound_tp(black_box(300.0), black_box(80e6)))
+        });
+
+        c.bench_function("Region 1 speed_sound_tp-3", |b| {
+            b.iter(|| iapws97::speed_sound_tp(black_box(500.0), black_box(3e6)))
+        });
+
+        // Region 1 temperature_ps
+        c.bench_function("Region 1 temperature_ps-1", |b| {
+            b.iter(|| iapws97::temperature_ps(black_box(3e6), black_box(0.5)))
+        });
+
+        c.bench_function("Region 1 temperature_ps-2", |b| {
+            b.iter(|| iapws97::temperature_ps(black_box(80e6), black_box(0.5)))
+        });
+
+        c.bench_function("Region 1 temperature_ps-3", |b| {
+            b.iter(|| iapws97::temperature_ps(black_box(80e6), black_box(3.0)))
+        });
+
+        // Region 1 temperature_ph
+        c.bench_function("Region 1 temperature_ph-1", |b| {
+            b.iter(|| iapws97::temperature_ph(black_box(3e6), black_box(500.0)))
+        });
+
+        c.bench_function("Region 1 temperature_ph-2", |b| {
+            b.iter(|| iapws97::temperature_ph(black_box(80e6), black_box(500.0)))
+        });
+
+        c.bench_function("Region 1 temperature_ph-3", |b| {
+            b.iter(|| iapws97::temperature_ph(black_box(80e6), black_box(1500.0)))
+        });
+    }
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/benches/region2.rs
+++ b/benches/region2.rs
@@ -2,166 +2,329 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rust_steam::iapws97;
 
 pub fn criterion_benchmark(c: &mut Criterion) {
-    // Region 2 hmass_tp
-    c.bench_function("Region 2 hmass_tp-1", |b| {
-        b.iter(|| iapws97::hmass_tp(black_box(300.0), black_box(0.0035e6)))
-    });
+    if cfg!(feature = "nightly") {
+        // Region 2 hmass_tp
+        c.bench_function("SIMD Region 2 hmass_tp-1", |b| {
+            b.iter(|| iapws97::hmass_tp(black_box(300.0), black_box(0.0035e6)))
+        });
 
-    c.bench_function("Region 2 hmass_tp-2", |b| {
-        b.iter(|| iapws97::hmass_tp(black_box(700.0), black_box(0.0035e6)))
-    });
+        c.bench_function("SIMD Region 2 hmass_tp-2", |b| {
+            b.iter(|| iapws97::hmass_tp(black_box(700.0), black_box(0.0035e6)))
+        });
 
-    c.bench_function("Region 2 hmass_tp-3", |b| {
-        b.iter(|| iapws97::hmass_tp(black_box(700.0), black_box(30e6)))
-    });
+        c.bench_function("SIMD Region 2 hmass_tp-3", |b| {
+            b.iter(|| iapws97::hmass_tp(black_box(700.0), black_box(30e6)))
+        });
 
-    // Region 2 umass_tp
-    c.bench_function("Region 2 umass_tp-1", |b| {
-        b.iter(|| iapws97::umass_tp(black_box(300.0), black_box(0.0035e6)))
-    });
+        // Region 2 umass_tp
+        c.bench_function("SIMD Region 2 umass_tp-1", |b| {
+            b.iter(|| iapws97::umass_tp(black_box(300.0), black_box(0.0035e6)))
+        });
 
-    c.bench_function("Region 2 umass_tp-2", |b| {
-        b.iter(|| iapws97::umass_tp(black_box(700.0), black_box(0.0035e6)))
-    });
+        c.bench_function("SIMD Region 2 umass_tp-2", |b| {
+            b.iter(|| iapws97::umass_tp(black_box(700.0), black_box(0.0035e6)))
+        });
 
-    c.bench_function("Region 2 umass_tp-3", |b| {
-        b.iter(|| iapws97::hmass_tp(black_box(700.0), black_box(30e6)))
-    });
+        c.bench_function("SIMD Region 2 umass_tp-3", |b| {
+            b.iter(|| iapws97::hmass_tp(black_box(700.0), black_box(30e6)))
+        });
 
-    // Region 2 smass_tp
-    c.bench_function("Region 2 smass_tp-1", |b| {
-        b.iter(|| iapws97::smass_tp(black_box(300.0), black_box(0.0035e6)))
-    });
+        // Region 2 smass_tp
+        c.bench_function("SIMD Region 2 smass_tp-1", |b| {
+            b.iter(|| iapws97::smass_tp(black_box(300.0), black_box(0.0035e6)))
+        });
 
-    c.bench_function("Region 2 smass_tp-2", |b| {
-        b.iter(|| iapws97::smass_tp(black_box(700.0), black_box(0.0035e6)))
-    });
+        c.bench_function("SIMD Region 2 smass_tp-2", |b| {
+            b.iter(|| iapws97::smass_tp(black_box(700.0), black_box(0.0035e6)))
+        });
 
-    c.bench_function("Region 2 smass_tp-3", |b| {
-        b.iter(|| iapws97::smass_tp(black_box(700.0), black_box(30e6)))
-    });
+        c.bench_function("SIMD Region 2 smass_tp-3", |b| {
+            b.iter(|| iapws97::smass_tp(black_box(700.0), black_box(30e6)))
+        });
 
-    // Region 2 cpmass_tp
-    c.bench_function("Region 2 cpmass_tp-1", |b| {
-        b.iter(|| iapws97::cpmass_tp(black_box(300.0), black_box(0.0035e6)))
-    });
+        // Region 2 cpmass_tp
+        c.bench_function("SIMD Region 2 cpmass_tp-1", |b| {
+            b.iter(|| iapws97::cpmass_tp(black_box(300.0), black_box(0.0035e6)))
+        });
 
-    c.bench_function("Region 2 cpmass_tp-2", |b| {
-        b.iter(|| iapws97::cpmass_tp(black_box(700.0), black_box(0.0035e6)))
-    });
+        c.bench_function("SIMD Region 2 cpmass_tp-2", |b| {
+            b.iter(|| iapws97::cpmass_tp(black_box(700.0), black_box(0.0035e6)))
+        });
 
-    c.bench_function("Region 2 cpmass_tp-3", |b| {
-        b.iter(|| iapws97::cpmass_tp(black_box(700.0), black_box(30e6)))
-    });
+        c.bench_function("SIMD Region 2 cpmass_tp-3", |b| {
+            b.iter(|| iapws97::cpmass_tp(black_box(700.0), black_box(30e6)))
+        });
 
-    // Region 2 cvmass_tp
-    c.bench_function("Region 2 cvmass_tp-1", |b| {
-        b.iter(|| iapws97::cvmass_tp(black_box(300.0), black_box(0.0035e6)))
-    });
+        // Region 2 cvmass_tp
+        c.bench_function("SIMD Region 2 cvmass_tp-1", |b| {
+            b.iter(|| iapws97::cvmass_tp(black_box(300.0), black_box(0.0035e6)))
+        });
 
-    c.bench_function("Region 2 cvmass_tp-2", |b| {
-        b.iter(|| iapws97::cvmass_tp(black_box(700.0), black_box(0.0035e6)))
-    });
+        c.bench_function("SIMD Region 2 cvmass_tp-2", |b| {
+            b.iter(|| iapws97::cvmass_tp(black_box(700.0), black_box(0.0035e6)))
+        });
 
-    c.bench_function("Region 2 cvmass_tp-3", |b| {
-        b.iter(|| iapws97::cvmass_tp(black_box(700.0), black_box(30e6)))
-    });
+        c.bench_function("SIMD Region 2 cvmass_tp-3", |b| {
+            b.iter(|| iapws97::cvmass_tp(black_box(700.0), black_box(30e6)))
+        });
 
-    // Region 2 vmass_tp
-    c.bench_function("Region 2 vmass_tp-1", |b| {
-        b.iter(|| iapws97::vmass_tp(black_box(300.0), black_box(0.0035e6)))
-    });
+        // Region 2 vmass_tp
+        c.bench_function("SIMD Region 2 vmass_tp-1", |b| {
+            b.iter(|| iapws97::vmass_tp(black_box(300.0), black_box(0.0035e6)))
+        });
 
-    c.bench_function("Region 2 vmass_tp-2", |b| {
-        b.iter(|| iapws97::vmass_tp(black_box(700.0), black_box(0.0035e6)))
-    });
+        c.bench_function("SIMD Region 2 vmass_tp-2", |b| {
+            b.iter(|| iapws97::vmass_tp(black_box(700.0), black_box(0.0035e6)))
+        });
 
-    c.bench_function("Region 2 vmass_tp-3", |b| {
-        b.iter(|| iapws97::vmass_tp(black_box(700.0), black_box(30e6)))
-    });
+        c.bench_function("SIMD Region 2 vmass_tp-3", |b| {
+            b.iter(|| iapws97::vmass_tp(black_box(700.0), black_box(30e6)))
+        });
 
-    // Region 2 speed_sound_tp
-    c.bench_function("Region 2 speed_sound_tp-1", |b| {
-        b.iter(|| iapws97::speed_sound_tp(black_box(300.0), black_box(0.0035e6)))
-    });
+        // Region 2 speed_sound_tp
+        c.bench_function("SIMD Region 2 speed_sound_tp-1", |b| {
+            b.iter(|| iapws97::speed_sound_tp(black_box(300.0), black_box(0.0035e6)))
+        });
 
-    c.bench_function("Region 2 speed_sound_tp-2", |b| {
-        b.iter(|| iapws97::speed_sound_tp(black_box(700.0), black_box(0.0035e6)))
-    });
+        c.bench_function("SIMD Region 2 speed_sound_tp-2", |b| {
+            b.iter(|| iapws97::speed_sound_tp(black_box(700.0), black_box(0.0035e6)))
+        });
 
-    c.bench_function("Region 2 speed_sound_tp-3", |b| {
-        b.iter(|| iapws97::speed_sound_tp(black_box(700.0), black_box(30e6)))
-    });
+        c.bench_function("SIMD Region 2 speed_sound_tp-3", |b| {
+            b.iter(|| iapws97::speed_sound_tp(black_box(700.0), black_box(30e6)))
+        });
 
-    // Region 2 temperature_ps
-    c.bench_function("Region 2 temperature_ps-1", |b| {
-        b.iter(|| iapws97::temperature_ps(black_box(0.001e6), black_box(3000.0)))
-    });
+        // Region 2 temperature_ps
+        c.bench_function("SIMD Region 2 temperature_ps-1", |b| {
+            b.iter(|| iapws97::temperature_ps(black_box(0.001e6), black_box(3000.0)))
+        });
 
-    c.bench_function("Region 2 temperature_ps-2", |b| {
-        b.iter(|| iapws97::temperature_ps(black_box(3e6), black_box(3000.0)))
-    });
+        c.bench_function("SIMD Region 2 temperature_ps-2", |b| {
+            b.iter(|| iapws97::temperature_ps(black_box(3e6), black_box(3000.0)))
+        });
 
-    c.bench_function("Region 2 temperature_ps-3", |b| {
-        b.iter(|| iapws97::temperature_ps(black_box(3e6), black_box(4000.0)))
-    });
-    c.bench_function("Region 2 temperature_ps-4", |b| {
-        b.iter(|| iapws97::temperature_ps(black_box(5e6), black_box(3500.0)))
-    });
+        c.bench_function("SIMD Region 2 temperature_ps-3", |b| {
+            b.iter(|| iapws97::temperature_ps(black_box(3e6), black_box(4000.0)))
+        });
+        c.bench_function("SIMD Region 2 temperature_ps-4", |b| {
+            b.iter(|| iapws97::temperature_ps(black_box(5e6), black_box(3500.0)))
+        });
 
-    c.bench_function("Region 2 temperature_ps-5", |b| {
-        b.iter(|| iapws97::temperature_ps(black_box(5e6), black_box(4000.0)))
-    });
+        c.bench_function("SIMD Region 2 temperature_ps-5", |b| {
+            b.iter(|| iapws97::temperature_ps(black_box(5e6), black_box(4000.0)))
+        });
 
-    c.bench_function("Region 2 temperature_ps-6", |b| {
-        b.iter(|| iapws97::temperature_ps(black_box(25e6), black_box(3500.0)))
-    });
-    c.bench_function("Region 2 temperature_ps-7", |b| {
-        b.iter(|| iapws97::temperature_ps(black_box(40e6), black_box(2700.0)))
-    });
+        c.bench_function("SIMD Region 2 temperature_ps-6", |b| {
+            b.iter(|| iapws97::temperature_ps(black_box(25e6), black_box(3500.0)))
+        });
+        c.bench_function("SIMD Region 2 temperature_ps-7", |b| {
+            b.iter(|| iapws97::temperature_ps(black_box(40e6), black_box(2700.0)))
+        });
 
-    c.bench_function("Region 2 temperature_ps-8", |b| {
-        b.iter(|| iapws97::temperature_ps(black_box(60e6), black_box(2700.0)))
-    });
+        c.bench_function("SIMD Region 2 temperature_ps-8", |b| {
+            b.iter(|| iapws97::temperature_ps(black_box(60e6), black_box(2700.0)))
+        });
 
-    c.bench_function("Region 2 temperature_ps-9", |b| {
-        b.iter(|| iapws97::temperature_ps(black_box(60e6), black_box(3200.0)))
-    });
+        c.bench_function("SIMD Region 2 temperature_ps-9", |b| {
+            b.iter(|| iapws97::temperature_ps(black_box(60e6), black_box(3200.0)))
+        });
 
-    // Region 2 temperature_ph
-    c.bench_function("Region 2 temperature_ph-1", |b| {
-        b.iter(|| iapws97::temperature_ph(black_box(0.1e6), black_box(7.5)))
-    });
+        // Region 2 temperature_ph
+        c.bench_function("SIMD Region 2 temperature_ph-1", |b| {
+            b.iter(|| iapws97::temperature_ph(black_box(0.1e6), black_box(7.5)))
+        });
 
-    c.bench_function("Region 2 temperature_ph-2", |b| {
-        b.iter(|| iapws97::temperature_ph(black_box(0.1e6), black_box(8.0)))
-    });
+        c.bench_function("SIMD Region 2 temperature_ph-2", |b| {
+            b.iter(|| iapws97::temperature_ph(black_box(0.1e6), black_box(8.0)))
+        });
 
-    c.bench_function("Region 2 temperature_ph-3", |b| {
-        b.iter(|| iapws97::temperature_ph(black_box(2.5e6), black_box(8.0)))
-    });
-    c.bench_function("Region 2 temperature_ph-4", |b| {
-        b.iter(|| iapws97::temperature_ph(black_box(8e6), black_box(6.0)))
-    });
+        c.bench_function("SIMD Region 2 temperature_ph-3", |b| {
+            b.iter(|| iapws97::temperature_ph(black_box(2.5e6), black_box(8.0)))
+        });
+        c.bench_function("SIMD Region 2 temperature_ph-4", |b| {
+            b.iter(|| iapws97::temperature_ph(black_box(8e6), black_box(6.0)))
+        });
 
-    c.bench_function("Region 2 temperature_ph-5", |b| {
-        b.iter(|| iapws97::temperature_ph(black_box(8e6), black_box(7.5)))
-    });
+        c.bench_function("SIMD Region 2 temperature_ph-5", |b| {
+            b.iter(|| iapws97::temperature_ph(black_box(8e6), black_box(7.5)))
+        });
 
-    c.bench_function("Region 2 temperature_ph-6", |b| {
-        b.iter(|| iapws97::temperature_ph(black_box(90e6), black_box(6.0)))
-    });
-    c.bench_function("Region 2 temperature_ph-7", |b| {
-        b.iter(|| iapws97::temperature_ph(black_box(20e6), black_box(5.75)))
-    });
+        c.bench_function("SIMD Region 2 temperature_ph-6", |b| {
+            b.iter(|| iapws97::temperature_ph(black_box(90e6), black_box(6.0)))
+        });
+        c.bench_function("SIMD Region 2 temperature_ph-7", |b| {
+            b.iter(|| iapws97::temperature_ph(black_box(20e6), black_box(5.75)))
+        });
 
-    c.bench_function("Region 2 temperature_ph-8", |b| {
-        b.iter(|| iapws97::temperature_ph(black_box(80e6), black_box(5.25)))
-    });
+        c.bench_function("SIMD Region 2 temperature_ph-8", |b| {
+            b.iter(|| iapws97::temperature_ph(black_box(80e6), black_box(5.25)))
+        });
 
-    c.bench_function("Region 2 temperature_ph-9", |b| {
-        b.iter(|| iapws97::temperature_ph(black_box(80e6), black_box(5.75)))
-    });
+        c.bench_function("SIMD Region 2 temperature_ph-9", |b| {
+            b.iter(|| iapws97::temperature_ph(black_box(80e6), black_box(5.75)))
+        });
+    } else {
+        // Region 2 hmass_tp
+        c.bench_function("Region 2 hmass_tp-1", |b| {
+            b.iter(|| iapws97::hmass_tp(black_box(300.0), black_box(0.0035e6)))
+        });
+
+        c.bench_function("Region 2 hmass_tp-2", |b| {
+            b.iter(|| iapws97::hmass_tp(black_box(700.0), black_box(0.0035e6)))
+        });
+
+        c.bench_function("Region 2 hmass_tp-3", |b| {
+            b.iter(|| iapws97::hmass_tp(black_box(700.0), black_box(30e6)))
+        });
+
+        // Region 2 umass_tp
+        c.bench_function("Region 2 umass_tp-1", |b| {
+            b.iter(|| iapws97::umass_tp(black_box(300.0), black_box(0.0035e6)))
+        });
+
+        c.bench_function("Region 2 umass_tp-2", |b| {
+            b.iter(|| iapws97::umass_tp(black_box(700.0), black_box(0.0035e6)))
+        });
+
+        c.bench_function("Region 2 umass_tp-3", |b| {
+            b.iter(|| iapws97::hmass_tp(black_box(700.0), black_box(30e6)))
+        });
+
+        // Region 2 smass_tp
+        c.bench_function("Region 2 smass_tp-1", |b| {
+            b.iter(|| iapws97::smass_tp(black_box(300.0), black_box(0.0035e6)))
+        });
+
+        c.bench_function("Region 2 smass_tp-2", |b| {
+            b.iter(|| iapws97::smass_tp(black_box(700.0), black_box(0.0035e6)))
+        });
+
+        c.bench_function("Region 2 smass_tp-3", |b| {
+            b.iter(|| iapws97::smass_tp(black_box(700.0), black_box(30e6)))
+        });
+
+        // Region 2 cpmass_tp
+        c.bench_function("Region 2 cpmass_tp-1", |b| {
+            b.iter(|| iapws97::cpmass_tp(black_box(300.0), black_box(0.0035e6)))
+        });
+
+        c.bench_function("Region 2 cpmass_tp-2", |b| {
+            b.iter(|| iapws97::cpmass_tp(black_box(700.0), black_box(0.0035e6)))
+        });
+
+        c.bench_function("Region 2 cpmass_tp-3", |b| {
+            b.iter(|| iapws97::cpmass_tp(black_box(700.0), black_box(30e6)))
+        });
+
+        // Region 2 cvmass_tp
+        c.bench_function("Region 2 cvmass_tp-1", |b| {
+            b.iter(|| iapws97::cvmass_tp(black_box(300.0), black_box(0.0035e6)))
+        });
+
+        c.bench_function("Region 2 cvmass_tp-2", |b| {
+            b.iter(|| iapws97::cvmass_tp(black_box(700.0), black_box(0.0035e6)))
+        });
+
+        c.bench_function("Region 2 cvmass_tp-3", |b| {
+            b.iter(|| iapws97::cvmass_tp(black_box(700.0), black_box(30e6)))
+        });
+
+        // Region 2 vmass_tp
+        c.bench_function("Region 2 vmass_tp-1", |b| {
+            b.iter(|| iapws97::vmass_tp(black_box(300.0), black_box(0.0035e6)))
+        });
+
+        c.bench_function("Region 2 vmass_tp-2", |b| {
+            b.iter(|| iapws97::vmass_tp(black_box(700.0), black_box(0.0035e6)))
+        });
+
+        c.bench_function("Region 2 vmass_tp-3", |b| {
+            b.iter(|| iapws97::vmass_tp(black_box(700.0), black_box(30e6)))
+        });
+
+        // Region 2 speed_sound_tp
+        c.bench_function("Region 2 speed_sound_tp-1", |b| {
+            b.iter(|| iapws97::speed_sound_tp(black_box(300.0), black_box(0.0035e6)))
+        });
+
+        c.bench_function("Region 2 speed_sound_tp-2", |b| {
+            b.iter(|| iapws97::speed_sound_tp(black_box(700.0), black_box(0.0035e6)))
+        });
+
+        c.bench_function("Region 2 speed_sound_tp-3", |b| {
+            b.iter(|| iapws97::speed_sound_tp(black_box(700.0), black_box(30e6)))
+        });
+
+        // Region 2 temperature_ps
+        c.bench_function("Region 2 temperature_ps-1", |b| {
+            b.iter(|| iapws97::temperature_ps(black_box(0.001e6), black_box(3000.0)))
+        });
+
+        c.bench_function("Region 2 temperature_ps-2", |b| {
+            b.iter(|| iapws97::temperature_ps(black_box(3e6), black_box(3000.0)))
+        });
+
+        c.bench_function("Region 2 temperature_ps-3", |b| {
+            b.iter(|| iapws97::temperature_ps(black_box(3e6), black_box(4000.0)))
+        });
+        c.bench_function("Region 2 temperature_ps-4", |b| {
+            b.iter(|| iapws97::temperature_ps(black_box(5e6), black_box(3500.0)))
+        });
+
+        c.bench_function("Region 2 temperature_ps-5", |b| {
+            b.iter(|| iapws97::temperature_ps(black_box(5e6), black_box(4000.0)))
+        });
+
+        c.bench_function("Region 2 temperature_ps-6", |b| {
+            b.iter(|| iapws97::temperature_ps(black_box(25e6), black_box(3500.0)))
+        });
+        c.bench_function("Region 2 temperature_ps-7", |b| {
+            b.iter(|| iapws97::temperature_ps(black_box(40e6), black_box(2700.0)))
+        });
+
+        c.bench_function("Region 2 temperature_ps-8", |b| {
+            b.iter(|| iapws97::temperature_ps(black_box(60e6), black_box(2700.0)))
+        });
+
+        c.bench_function("Region 2 temperature_ps-9", |b| {
+            b.iter(|| iapws97::temperature_ps(black_box(60e6), black_box(3200.0)))
+        });
+
+        // Region 2 temperature_ph
+        c.bench_function("Region 2 temperature_ph-1", |b| {
+            b.iter(|| iapws97::temperature_ph(black_box(0.1e6), black_box(7.5)))
+        });
+
+        c.bench_function("Region 2 temperature_ph-2", |b| {
+            b.iter(|| iapws97::temperature_ph(black_box(0.1e6), black_box(8.0)))
+        });
+
+        c.bench_function("Region 2 temperature_ph-3", |b| {
+            b.iter(|| iapws97::temperature_ph(black_box(2.5e6), black_box(8.0)))
+        });
+        c.bench_function("Region 2 temperature_ph-4", |b| {
+            b.iter(|| iapws97::temperature_ph(black_box(8e6), black_box(6.0)))
+        });
+
+        c.bench_function("Region 2 temperature_ph-5", |b| {
+            b.iter(|| iapws97::temperature_ph(black_box(8e6), black_box(7.5)))
+        });
+
+        c.bench_function("Region 2 temperature_ph-6", |b| {
+            b.iter(|| iapws97::temperature_ph(black_box(90e6), black_box(6.0)))
+        });
+        c.bench_function("Region 2 temperature_ph-7", |b| {
+            b.iter(|| iapws97::temperature_ph(black_box(20e6), black_box(5.75)))
+        });
+
+        c.bench_function("Region 2 temperature_ph-8", |b| {
+            b.iter(|| iapws97::temperature_ph(black_box(80e6), black_box(5.25)))
+        });
+
+        c.bench_function("Region 2 temperature_ph-9", |b| {
+            b.iter(|| iapws97::temperature_ph(black_box(80e6), black_box(5.75)))
+        });
+    }
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/benches/region3.rs
+++ b/benches/region3.rs
@@ -2,96 +2,189 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rust_steam::iapws97;
 
 pub fn criterion_benchmark(c: &mut Criterion) {
-    // Region 3 hmass_tp
-    c.bench_function("Region 3 hmass_tp-1", |b| {
-        b.iter(|| iapws97::hmass_tp(black_box(650.0), black_box(25.5837018e6)))
-    });
+    if cfg!(feature = "nightly") {
+        // Region 3 hmass_tp
+        c.bench_function("SIMD Region 3 hmass_tp-1", |b| {
+            b.iter(|| iapws97::hmass_tp(black_box(650.0), black_box(25.5837018e6)))
+        });
 
-    c.bench_function("Region 3 hmass_tp-2", |b| {
-        b.iter(|| iapws97::hmass_tp(black_box(650.0), black_box(22.2930643e6)))
-    });
+        c.bench_function("SIMD Region 3 hmass_tp-2", |b| {
+            b.iter(|| iapws97::hmass_tp(black_box(650.0), black_box(22.2930643e6)))
+        });
 
-    c.bench_function("Region 3 hmass_tp-3", |b| {
-        b.iter(|| iapws97::hmass_tp(black_box(750.0), black_box(78.3095639e6)))
-    });
+        c.bench_function("SIMD Region 3 hmass_tp-3", |b| {
+            b.iter(|| iapws97::hmass_tp(black_box(750.0), black_box(78.3095639e6)))
+        });
 
-    // Region 3 umass_tp
-    c.bench_function("Region 3 umass_tp-1", |b| {
-        b.iter(|| iapws97::umass_tp(black_box(650.0), black_box(25.5837018e6)))
-    });
+        // Region 3 umass_tp
+        c.bench_function("SIMD Region 3 umass_tp-1", |b| {
+            b.iter(|| iapws97::umass_tp(black_box(650.0), black_box(25.5837018e6)))
+        });
 
-    c.bench_function("Region 3 umass_tp-2", |b| {
-        b.iter(|| iapws97::umass_tp(black_box(650.0), black_box(22.2930643e6)))
-    });
+        c.bench_function("SIMD Region 3 umass_tp-2", |b| {
+            b.iter(|| iapws97::umass_tp(black_box(650.0), black_box(22.2930643e6)))
+        });
 
-    c.bench_function("Region 3 umass_tp-3", |b| {
-        b.iter(|| iapws97::umass_tp(black_box(750.0), black_box(78.3095639e6)))
-    });
+        c.bench_function("SIMD Region 3 umass_tp-3", |b| {
+            b.iter(|| iapws97::umass_tp(black_box(750.0), black_box(78.3095639e6)))
+        });
 
-    // Region 3 smass_tp
-    c.bench_function("Region 3 smass_tp-1", |b| {
-        b.iter(|| iapws97::smass_tp(black_box(650.0), black_box(25.5837018e6)))
-    });
+        // Region 3 smass_tp
+        c.bench_function("SIMD Region 3 smass_tp-1", |b| {
+            b.iter(|| iapws97::smass_tp(black_box(650.0), black_box(25.5837018e6)))
+        });
 
-    c.bench_function("Region 3 smass_tp-2", |b| {
-        b.iter(|| iapws97::smass_tp(black_box(650.0), black_box(22.2930643e6)))
-    });
+        c.bench_function("SIMD Region 3 smass_tp-2", |b| {
+            b.iter(|| iapws97::smass_tp(black_box(650.0), black_box(22.2930643e6)))
+        });
 
-    c.bench_function("Region 3 smass_tp-3", |b| {
-        b.iter(|| iapws97::smass_tp(black_box(750.0), black_box(78.3095639e6)))
-    });
+        c.bench_function("SIMD Region 3 smass_tp-3", |b| {
+            b.iter(|| iapws97::smass_tp(black_box(750.0), black_box(78.3095639e6)))
+        });
 
-    // Region 3 cpmass_tp
-    c.bench_function("Region 3 cpmass_tp-1", |b| {
-        b.iter(|| iapws97::cpmass_tp(black_box(650.0), black_box(25.5837018e6)))
-    });
+        // Region 3 cpmass_tp
+        c.bench_function("SIMD Region 3 cpmass_tp-1", |b| {
+            b.iter(|| iapws97::cpmass_tp(black_box(650.0), black_box(25.5837018e6)))
+        });
 
-    c.bench_function("Region 3 cpmass_tp-2", |b| {
-        b.iter(|| iapws97::cpmass_tp(black_box(650.0), black_box(22.2930643e6)))
-    });
+        c.bench_function("SIMD Region 3 cpmass_tp-2", |b| {
+            b.iter(|| iapws97::cpmass_tp(black_box(650.0), black_box(22.2930643e6)))
+        });
 
-    c.bench_function("Region 3 cpmass_tp-3", |b| {
-        b.iter(|| iapws97::cpmass_tp(black_box(750.0), black_box(78.3095639e6)))
-    });
+        c.bench_function("SIMD Region 3 cpmass_tp-3", |b| {
+            b.iter(|| iapws97::cpmass_tp(black_box(750.0), black_box(78.3095639e6)))
+        });
 
-    // Region 3 cvmass_tp
-    c.bench_function("Region 3 cvmass_tp-1", |b| {
-        b.iter(|| iapws97::cvmass_tp(black_box(650.0), black_box(25.5837018e6)))
-    });
+        // Region 3 cvmass_tp
+        c.bench_function("SIMD Region 3 cvmass_tp-1", |b| {
+            b.iter(|| iapws97::cvmass_tp(black_box(650.0), black_box(25.5837018e6)))
+        });
 
-    c.bench_function("Region 3 cvmass_tp-2", |b| {
-        b.iter(|| iapws97::cvmass_tp(black_box(650.0), black_box(22.2930643e6)))
-    });
+        c.bench_function("SIMD Region 3 cvmass_tp-2", |b| {
+            b.iter(|| iapws97::cvmass_tp(black_box(650.0), black_box(22.2930643e6)))
+        });
 
-    c.bench_function("Region 3 cvmass_tp-3", |b| {
-        b.iter(|| iapws97::cvmass_tp(black_box(750.0), black_box(78.3095639e6)))
-    });
+        c.bench_function("SIMD Region 3 cvmass_tp-3", |b| {
+            b.iter(|| iapws97::cvmass_tp(black_box(750.0), black_box(78.3095639e6)))
+        });
 
-    // Region 3 vmass_tp
-    c.bench_function("Region 3 vmass_tp-1", |b| {
-        b.iter(|| iapws97::vmass_tp(black_box(650.0), black_box(25.5837018e6)))
-    });
+        // Region 3 vmass_tp
+        c.bench_function("SIMD Region 3 vmass_tp-1", |b| {
+            b.iter(|| iapws97::vmass_tp(black_box(650.0), black_box(25.5837018e6)))
+        });
 
-    c.bench_function("Region 3 vmass_tp-2", |b| {
-        b.iter(|| iapws97::vmass_tp(black_box(650.0), black_box(22.2930643e6)))
-    });
+        c.bench_function("SIMD Region 3 vmass_tp-2", |b| {
+            b.iter(|| iapws97::vmass_tp(black_box(650.0), black_box(22.2930643e6)))
+        });
 
-    c.bench_function("Region 3 vmass_tp-3", |b| {
-        b.iter(|| iapws97::vmass_tp(black_box(750.0), black_box(78.3095639e6)))
-    });
+        c.bench_function("SIMD Region 3 vmass_tp-3", |b| {
+            b.iter(|| iapws97::vmass_tp(black_box(750.0), black_box(78.3095639e6)))
+        });
 
-    // Region 3 speed_sound_tp
-    c.bench_function("Region 3 speed_sound_tp-1", |b| {
-        b.iter(|| iapws97::speed_sound_tp(black_box(650.0), black_box(25.5837018e6)))
-    });
+        // Region 3 speed_sound_tp
+        c.bench_function("SIMD Region 3 speed_sound_tp-1", |b| {
+            b.iter(|| iapws97::speed_sound_tp(black_box(650.0), black_box(25.5837018e6)))
+        });
 
-    c.bench_function("Region 3 speed_sound_tp-2", |b| {
-        b.iter(|| iapws97::speed_sound_tp(black_box(650.0), black_box(22.2930643e6)))
-    });
+        c.bench_function("SIMD Region 3 speed_sound_tp-2", |b| {
+            b.iter(|| iapws97::speed_sound_tp(black_box(650.0), black_box(22.2930643e6)))
+        });
 
-    c.bench_function("Region 3 speed_sound_tp-3", |b| {
-        b.iter(|| iapws97::speed_sound_tp(black_box(750.0), black_box(78.3095639e6)))
-    });
+        c.bench_function("SIMD Region 3 speed_sound_tp-3", |b| {
+            b.iter(|| iapws97::speed_sound_tp(black_box(750.0), black_box(78.3095639e6)))
+        });
+    } else {
+        // Region 3 hmass_tp
+        c.bench_function("Region 3 hmass_tp-1", |b| {
+            b.iter(|| iapws97::hmass_tp(black_box(650.0), black_box(25.5837018e6)))
+        });
+
+        c.bench_function("Region 3 hmass_tp-2", |b| {
+            b.iter(|| iapws97::hmass_tp(black_box(650.0), black_box(22.2930643e6)))
+        });
+
+        c.bench_function("Region 3 hmass_tp-3", |b| {
+            b.iter(|| iapws97::hmass_tp(black_box(750.0), black_box(78.3095639e6)))
+        });
+
+        // Region 3 umass_tp
+        c.bench_function("Region 3 umass_tp-1", |b| {
+            b.iter(|| iapws97::umass_tp(black_box(650.0), black_box(25.5837018e6)))
+        });
+
+        c.bench_function("Region 3 umass_tp-2", |b| {
+            b.iter(|| iapws97::umass_tp(black_box(650.0), black_box(22.2930643e6)))
+        });
+
+        c.bench_function("Region 3 umass_tp-3", |b| {
+            b.iter(|| iapws97::umass_tp(black_box(750.0), black_box(78.3095639e6)))
+        });
+
+        // Region 3 smass_tp
+        c.bench_function("Region 3 smass_tp-1", |b| {
+            b.iter(|| iapws97::smass_tp(black_box(650.0), black_box(25.5837018e6)))
+        });
+
+        c.bench_function("Region 3 smass_tp-2", |b| {
+            b.iter(|| iapws97::smass_tp(black_box(650.0), black_box(22.2930643e6)))
+        });
+
+        c.bench_function("Region 3 smass_tp-3", |b| {
+            b.iter(|| iapws97::smass_tp(black_box(750.0), black_box(78.3095639e6)))
+        });
+
+        // Region 3 cpmass_tp
+        c.bench_function("Region 3 cpmass_tp-1", |b| {
+            b.iter(|| iapws97::cpmass_tp(black_box(650.0), black_box(25.5837018e6)))
+        });
+
+        c.bench_function("Region 3 cpmass_tp-2", |b| {
+            b.iter(|| iapws97::cpmass_tp(black_box(650.0), black_box(22.2930643e6)))
+        });
+
+        c.bench_function("Region 3 cpmass_tp-3", |b| {
+            b.iter(|| iapws97::cpmass_tp(black_box(750.0), black_box(78.3095639e6)))
+        });
+
+        // Region 3 cvmass_tp
+        c.bench_function("Region 3 cvmass_tp-1", |b| {
+            b.iter(|| iapws97::cvmass_tp(black_box(650.0), black_box(25.5837018e6)))
+        });
+
+        c.bench_function("Region 3 cvmass_tp-2", |b| {
+            b.iter(|| iapws97::cvmass_tp(black_box(650.0), black_box(22.2930643e6)))
+        });
+
+        c.bench_function("Region 3 cvmass_tp-3", |b| {
+            b.iter(|| iapws97::cvmass_tp(black_box(750.0), black_box(78.3095639e6)))
+        });
+
+        // Region 3 vmass_tp
+        c.bench_function("Region 3 vmass_tp-1", |b| {
+            b.iter(|| iapws97::vmass_tp(black_box(650.0), black_box(25.5837018e6)))
+        });
+
+        c.bench_function("Region 3 vmass_tp-2", |b| {
+            b.iter(|| iapws97::vmass_tp(black_box(650.0), black_box(22.2930643e6)))
+        });
+
+        c.bench_function("Region 3 vmass_tp-3", |b| {
+            b.iter(|| iapws97::vmass_tp(black_box(750.0), black_box(78.3095639e6)))
+        });
+
+        // Region 3 speed_sound_tp
+        c.bench_function("Region 3 speed_sound_tp-1", |b| {
+            b.iter(|| iapws97::speed_sound_tp(black_box(650.0), black_box(25.5837018e6)))
+        });
+
+        c.bench_function("Region 3 speed_sound_tp-2", |b| {
+            b.iter(|| iapws97::speed_sound_tp(black_box(650.0), black_box(22.2930643e6)))
+        });
+
+        c.bench_function("Region 3 speed_sound_tp-3", |b| {
+            b.iter(|| iapws97::speed_sound_tp(black_box(750.0), black_box(78.3095639e6)))
+        });
+    }
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/src/iapws97.rs
+++ b/src/iapws97.rs
@@ -1,5 +1,7 @@
+#![no_std]
+#![allow(unused_imports)]
+use intrinsics;
 pub mod iapws97 {
-
     mod constants;
     mod region_1;
     mod region_2;

--- a/src/iapws97.rs
+++ b/src/iapws97.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(portable_simd)]
+#![cfg_attr(feature = "nightly", feature(portable_simd))]
 
 pub mod iapws97 {
     #[cfg(not(feature = "std"))]

--- a/src/iapws97.rs
+++ b/src/iapws97.rs
@@ -1,6 +1,4 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#[allow(unused_imports)]
-#[allow(clippy::single_component_path_imports)]
 
 pub mod iapws97 {
     #[cfg(not(feature = "std"))]

--- a/src/iapws97.rs
+++ b/src/iapws97.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![feature(portable_simd)]
 
 pub mod iapws97 {
     #[cfg(not(feature = "std"))]

--- a/src/iapws97.rs
+++ b/src/iapws97.rs
@@ -1,6 +1,8 @@
 #![no_std]
-#![allow(unused_imports)]
+#[allow(unused_imports)]
+#[allow(clippy::single_component_path_imports)]
 use intrinsics;
+
 pub mod iapws97 {
     mod constants;
     mod region_1;

--- a/src/iapws97.rs
+++ b/src/iapws97.rs
@@ -1,9 +1,24 @@
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 #[allow(unused_imports)]
 #[allow(clippy::single_component_path_imports)]
-use intrinsics;
 
 pub mod iapws97 {
+    #[cfg(not(feature = "std"))]
+    #[allow(unused_imports)]
+    pub mod std {
+        pub use core::*;
+        // Optionally, use intrinsics if needed:
+        #[cfg(feature = "intrinsics")]
+        pub use intrinsics::*;
+    }
+
+    #[cfg(feature = "std")]
+    #[allow(unused_imports)]
+    pub mod std {
+        pub use std::*;
+    }
+
+    //
     mod constants;
     mod region_1;
     mod region_2;

--- a/src/iapws97/region_1.rs
+++ b/src/iapws97/region_1.rs
@@ -1,85 +1,110 @@
 use crate::iapws97::constants;
 
-const REGION_1_COEFFS: [[f64; 3]; 34] = [
-    [0.0, -2.0, 0.14632971213167],
-    [0.0, -1.0, -0.84548187169114],
-    [0.0, 0.0, -0.37563603672040e1],
-    [0.0, 1.0, 0.33855169168385e1],
-    [0.0, 2.0, -0.95791963387872],
-    [0.0, 3.0, 0.15772038513228],
-    [0.0, 4.0, -0.16616417199501e-1],
-    [0.0, 5.0, 0.81214629983568e-3],
-    [1.0, -9.0, 0.28319080123804e-3],
-    [1.0, -7.0, -0.60706301565874e-3],
-    [1.0, -1.0, -0.18990068218419e-1],
-    [1.0, 0.0, -0.32529748770505e-1],
-    [1.0, 1.0, -0.21841717175414e-1],
-    [1.0, 3.0, -0.52838357969930e-4],
-    [2.0, -3.0, -0.47184321073267e-3],
-    [2.0, 0.0, -0.30001780793026e-3],
-    [2.0, 1.0, 0.47661393906987e-4],
-    [2.0, 3.0, -0.44141845330846e-5],
-    [2.0, 17.0, -0.72694996297594e-15],
-    [3.0, -4.0, -0.31679644845054e-4],
-    [3.0, 0.0, -0.28270797985312e-5],
-    [3.0, 6.0, -0.85205128120103e-9],
-    [4.0, -5.0, -0.22425281908000e-5],
-    [4.0, -2.0, -0.65171222895601e-6],
-    [4.0, 10.0, -0.14341729937924e-12],
-    [5.0, -8.0, -0.40516996860117e-6],
-    [8.0, -11.0, -0.12734301741641e-8],
-    [8.0, -6.0, -0.17424871230634e-9],
-    [21.0, -29.0, -0.68762131295531e-18],
-    [23.0, -31.0, 0.14478307828521e-19],
-    [29.0, -38.0, 0.26335781662795e-22],
-    [30.0, -39.0, -0.11947622640071e-22],
-    [31.0, -40.0, 0.18228094581404e-23],
-    [32.0, -41.0, -0.93537087292458e-25],
+const REGION_1_COEFFS_II: [i32; 34] = [
+    0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 8, 8, 21, 23, 29,
+    30, 31, 32,
 ];
 
-const REGION_1_BACK_COEFFS_PH: [[f64; 3]; 20] = [
-    [0.0, 0.0, -0.23872489924521e+3],
-    [0.0, 1.0, 0.40421188637945e+3],
-    [0.0, 2.0, 0.11349746881718e+3],
-    [0.0, 6.0, -0.58457616048039e+1],
-    [0.0, 22.0, -0.15285482413140e-3],
-    [0.0, 32.0, -0.10866707695377e-5],
-    [1.0, 0.0, -0.13391744872602e+2],
-    [1.0, 1.0, 0.43211039183559e+2],
-    [1.0, 2.0, -0.54010067170506e+2],
-    [1.0, 3.0, 0.30535892203916e+2],
-    [1.0, 4.0, -0.65964749423638e+1],
-    [1.0, 10.0, 0.93965400878363e-2],
-    [1.0, 32.0, 0.11573647505340e-6],
-    [2.0, 10.0, -0.25858641282073e-4],
-    [2.0, 32.0, -0.40644363084799e-8],
-    [3.0, 10.0, 0.66456186191635e-7],
-    [3.0, 32.0, 0.80670734103027e-10],
-    [4.0, 32.0, -0.93477771213947e-12],
-    [5.0, 32.0, 0.58265442020601e-14],
-    [6.0, 32.0, -0.15020185953503e-16],
+const REGION_1_COEFFS_JI: [i32; 34] = [
+    -2, -1, 0, 1, 2, 3, 4, 5, -9, -7, -1, 0, 1, 3, -3, 0, 1, 3, 17, -4, 0, 6, -5, -2, 10, -8, -11,
+    -6, -29, -31, -38, -39, -40, -41,
 ];
-const REGION_1_BACK_COEFFS_PS: [[f64; 3]; 20] = [
-    [0.0, 0.0, 0.17478268058307e+03],
-    [0.0, 1.0, 0.34806930892873e+02],
-    [0.0, 2.0, 0.65292584978455e+01],
-    [0.0, 3.0, 0.33039981775489],
-    [0.0, 11.0, -0.19281382923196e-06],
-    [0.0, 31.0, -0.24909197244573e-22],
-    [1.0, 0.0, -0.26107636489332],
-    [1.0, 1.0, 0.22592965981586],
-    [1.0, 2.0, -0.64256463395226e-01],
-    [1.0, 3.0, 0.78876289270526e-02],
-    [1.0, 12.0, 0.35672110607366e-09],
-    [1.0, 31.0, 0.17332496994895e-23],
-    [2.0, 0.0, 0.56608900654837e-03],
-    [2.0, 1.0, -0.32635483139717e-03],
-    [2.0, 2.0, 0.44778286690632e-04],
-    [2.0, 9.0, -0.51322156908507e-09],
-    [2.0, 31.0, -0.42522657042207e-25],
-    [3.0, 10.0, 0.26400441360689e-12],
-    [3.0, 32.0, 0.78124600459723e-28],
-    [4.0, 32.0, -0.30732199903668e-30],
+
+const REGION_1_COEFFS_NI: [f64; 34] = [
+    0.14632971213167,
+    -0.84548187169114,
+    -0.37563603672040e1,
+    0.33855169168385e1,
+    -0.95791963387872,
+    0.15772038513228,
+    -0.16616417199501e-1,
+    0.81214629983568e-3,
+    0.28319080123804e-3,
+    -0.60706301565874e-3,
+    -0.18990068218419e-1,
+    -0.32529748770505e-1,
+    -0.21841717175414e-1,
+    -0.52838357969930e-4,
+    -0.47184321073267e-3,
+    -0.30001780793026e-3,
+    0.47661393906987e-4,
+    -0.44141845330846e-5,
+    -0.72694996297594e-15,
+    -0.31679644845054e-4,
+    -0.28270797985312e-5,
+    -0.85205128120103e-9,
+    -0.22425281908000e-5,
+    -0.65171222895601e-6,
+    -0.14341729937924e-12,
+    -0.40516996860117e-6,
+    -0.12734301741641e-8,
+    -0.17424871230634e-9,
+    -0.68762131295531e-18,
+    0.14478307828521e-19,
+    0.26335781662795e-22,
+    -0.11947622640071e-22,
+    0.18228094581404e-23,
+    -0.93537087292458e-25,
+];
+
+const REGION_1_BACK_COEFFS_PH_II: [i32; 20] =
+    [0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 2, 2, 3, 3, 4, 5, 6];
+
+const REGION_1_BACK_COEFFS_PH_JI: [i32; 20] = [
+    0, 1, 2, 6, 22, 32, 0, 1, 2, 3, 4, 10, 32, 10, 32, 10, 32, 32, 32, 32,
+];
+
+const REGION_1_BACK_COEFFS_PH_NI: [f64; 20] = [
+    -0.23872489924521e+3,
+    0.40421188637945e+3,
+    0.11349746881718e+3,
+    -0.58457616048039e+1,
+    -0.15285482413140e-3,
+    -0.10866707695377e-5,
+    -0.13391744872602e+2,
+    0.43211039183559e+2,
+    -0.54010067170506e+2,
+    0.30535892203916e+2,
+    -0.65964749423638e+1,
+    0.93965400878363e-2,
+    0.11573647505340e-6,
+    -0.25858641282073e-4,
+    -0.40644363084799e-8,
+    0.66456186191635e-7,
+    0.80670734103027e-10,
+    -0.93477771213947e-12,
+    0.58265442020601e-14,
+    -0.15020185953503e-16,
+];
+
+const REGION_1_BACK_COEFFS_PS_II: [i32; 20] =
+    [0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 4];
+
+const REGION_1_BACK_COEFFS_PS_JI: [i32; 20] = [
+    0, 1, 2, 3, 11, 31, 0, 1, 2, 3, 12, 31, 0, 1, 2, 9, 31, 10, 32, 32,
+];
+
+const REGION_1_BACK_COEFFS_PS_NI: [f64; 20] = [
+    0.17478268058307e+03,
+    0.34806930892873e+02,
+    0.65292584978455e+01,
+    0.33039981775489,
+    -0.19281382923196e-06,
+    -0.24909197244573e-22,
+    -0.26107636489332,
+    0.22592965981586,
+    -0.64256463395226e-01,
+    0.78876289270526e-02,
+    0.35672110607366e-09,
+    0.17332496994895e-23,
+    0.56608900654837e-03,
+    -0.32635483139717e-03,
+    0.44778286690632e-04,
+    -0.51322156908507e-09,
+    -0.42522657042207e-25,
+    0.26400441360689e-12,
+    0.78124600459723e-28,
+    -0.30732199903668e-30,
 ];
 
 // ================    Region 1 ===================
@@ -91,10 +116,10 @@ fn gamma_1(t: f64, p: f64) -> f64 {
     let tau = tau_1(t);
     let pi = pi_1(p);
     let mut sum = 0.0;
-    for coefficient in REGION_1_COEFFS {
-        let ii = coefficient[0] as i32;
-        let ji = coefficient[1] as i32;
-        let ni = coefficient[2];
+    for x in 0..REGION_1_COEFFS_II.len() {
+        let ii = REGION_1_COEFFS_II[x];
+        let ji = REGION_1_COEFFS_JI[x];
+        let ni = REGION_1_COEFFS_NI[x];
         sum += ni * (7.1 - pi).powi(ii) * (tau - 1.222).powi(ji);
     }
     sum
@@ -107,10 +132,10 @@ fn gamma_pi_1(t: f64, p: f64) -> f64 {
     let tau = tau_1(t);
     let pi = pi_1(p);
     let mut sum = 0.0;
-    for coefficient in REGION_1_COEFFS {
-        let ii = coefficient[0] as i32;
-        let ji = coefficient[1] as i32;
-        let ni = coefficient[2];
+    for x in 0..REGION_1_COEFFS_II.len() {
+        let ii = REGION_1_COEFFS_II[x];
+        let ji = REGION_1_COEFFS_JI[x];
+        let ni = REGION_1_COEFFS_NI[x];
         sum += -ni * f64::from(ii) * (7.1 - pi).powi(ii - 1) * (tau - 1.222).powi(ji);
     }
     sum
@@ -123,10 +148,10 @@ fn gamma_pi_pi_1(t: f64, p: f64) -> f64 {
     let tau = tau_1(t);
     let pi = pi_1(p);
     let mut sum = 0.0;
-    for coefficient in REGION_1_COEFFS {
-        let ii = coefficient[0] as i32;
-        let ji = coefficient[1] as i32;
-        let ni = coefficient[2];
+    for x in 0..REGION_1_COEFFS_II.len() {
+        let ii = REGION_1_COEFFS_II[x];
+        let ji = REGION_1_COEFFS_JI[x];
+        let ni = REGION_1_COEFFS_NI[x];
         sum += ni * f64::from(ii * (ii - 1)) * (7.1 - pi).powi(ii - 2) * (tau - 1.222).powi(ji);
     }
     sum
@@ -139,10 +164,10 @@ fn gamma_tau_1(t: f64, p: f64) -> f64 {
     let tau = tau_1(t);
     let pi = pi_1(p);
     let mut sum = 0.0;
-    for coefficient in REGION_1_COEFFS {
-        let ii = coefficient[0] as i32;
-        let ji = coefficient[1] as i32;
-        let ni = coefficient[2];
+    for x in 0..REGION_1_COEFFS_II.len() {
+        let ii = REGION_1_COEFFS_II[x];
+        let ji = REGION_1_COEFFS_JI[x];
+        let ni = REGION_1_COEFFS_NI[x];
         sum += ni * f64::from(ji) * (7.1 - pi).powi(ii) * (tau - 1.222).powi(ji - 1);
     }
     sum
@@ -155,10 +180,10 @@ fn gamma_tau_tau_1(t: f64, p: f64) -> f64 {
     let tau = tau_1(t);
     let pi = pi_1(p);
     let mut sum = 0.0;
-    for coefficient in REGION_1_COEFFS {
-        let ii = coefficient[0] as i32;
-        let ji = coefficient[1] as i32;
-        let ni = coefficient[2];
+    for x in 0..REGION_1_COEFFS_II.len() {
+        let ii = REGION_1_COEFFS_II[x];
+        let ji = REGION_1_COEFFS_JI[x];
+        let ni = REGION_1_COEFFS_NI[x];
         sum += ni * f64::from(ji * (ji - 1)) * (7.1 - pi).powi(ii) * (tau - 1.222).powi(ji - 2);
     }
     sum
@@ -171,10 +196,10 @@ fn gamma_pi_tau_1(t: f64, p: f64) -> f64 {
     let tau = tau_1(t);
     let pi = pi_1(p);
     let mut sum = 0.0;
-    for coefficient in REGION_1_COEFFS {
-        let ii = coefficient[0] as i32;
-        let ji = coefficient[1] as i32;
-        let ni = coefficient[2];
+    for x in 0..REGION_1_COEFFS_II.len() {
+        let ii = REGION_1_COEFFS_II[x];
+        let ji = REGION_1_COEFFS_JI[x];
+        let ni = REGION_1_COEFFS_NI[x];
         sum += -ni * f64::from(ii * ji) * (7.1 - pi).powi(ii - 1) * (tau - 1.222).powi(ji - 1);
     }
     sum
@@ -185,7 +210,7 @@ fn gamma_pi_tau_1(t: f64, p: f64) -> f64 {
 /// Pressure is assumed to be in Pa
 #[inline(always)]
 fn tau_1(t: f64) -> f64 {
-    1386.0 / t
+    1386.0_f64 / t
 }
 
 /// Returns the region-1 pi
@@ -210,7 +235,7 @@ pub(crate) fn h_tp_1(t: f64, p: f64) -> f64 {
 #[inline]
 pub(crate) fn v_tp_1(t: f64, p: f64) -> f64 {
     // The multiplication by 1000 is necessary to convert R from kJ/kg.K to J/kg.K
-    ((constants::_R * 1000.0) * t / p) * pi_1(p) * gamma_pi_1(t, p)
+    ((constants::_R * 1000.0_f64) * t / p) * pi_1(p) * gamma_pi_1(t, p)
 }
 
 /// Returns the region-1 specific internal energy
@@ -261,7 +286,7 @@ pub(crate) fn w_tp_1(t: f64, p: f64) -> f64 {
     let term = (gamma_pi - tau * gamma_pi_tau).powi(2) / (tau.powi(2) * gamma_tau_tau);
 
     // The multiplication by 1000 is necessary to convert R from kJ/kg.K to J/kg.K
-    let square = (constants::_R * 1000.0) * t * (gamma_pi.powi(2) / (term - gamma_pi_pi));
+    let square = (constants::_R * 1000.0_f64) * t * (gamma_pi.powi(2) / (term - gamma_pi_pi));
     square.sqrt()
 }
 
@@ -269,7 +294,7 @@ pub(crate) fn w_tp_1(t: f64, p: f64) -> f64 {
 /// Enthalpy is assumed to be in kJ/kg
 #[inline(always)]
 fn eta_1_back(h: f64) -> f64 {
-    h / 2500.0
+    h / 2500.0_f64
 }
 
 /// Returns the region-1 pi for backwards calculations
@@ -294,10 +319,10 @@ pub fn t_ps_1(p: f64, s: f64) -> f64 {
     let sig = sigma_1_back(s);
     let pi = pi_1_back(p);
     let mut sum = 0.0;
-    for coefficient in REGION_1_BACK_COEFFS_PS {
-        let ii = coefficient[0] as i32;
-        let ji = coefficient[1] as i32;
-        let ni = coefficient[2];
+    for x in 0..REGION_1_BACK_COEFFS_PS_II.len() {
+        let ii = REGION_1_BACK_COEFFS_PS_II[x];
+        let ji = REGION_1_BACK_COEFFS_PS_JI[x];
+        let ni = REGION_1_BACK_COEFFS_PS_NI[x];
         sum += ni * pi.powi(ii) * (sig + 2.0).powi(ji);
     }
     sum
@@ -311,10 +336,10 @@ pub fn t_ph_1(p: f64, h: f64) -> f64 {
     let eta = eta_1_back(h);
     let pi = pi_1_back(p);
     let mut sum = 0.0;
-    for coefficient in REGION_1_BACK_COEFFS_PH {
-        let ii = coefficient[0] as i32;
-        let ji = coefficient[1] as i32;
-        let ni = coefficient[2];
+    for x in 0..REGION_1_BACK_COEFFS_PH_II.len() {
+        let ii = REGION_1_BACK_COEFFS_PH_II[x];
+        let ji = REGION_1_BACK_COEFFS_PH_JI[x];
+        let ni = REGION_1_BACK_COEFFS_PH_NI[x];
         sum += ni * pi.powi(ii) * (eta + 1.0).powi(ji);
     }
     sum

--- a/src/iapws97/region_1.rs
+++ b/src/iapws97/region_1.rs
@@ -199,6 +199,7 @@ fn pi_1(p: f64) -> f64 {
 /// Returns the region-1 specific enthalpy
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
+#[inline]
 pub(crate) fn h_tp_1(t: f64, p: f64) -> f64 {
     constants::_R * t * tau_1(t) * gamma_tau_1(t, p)
 }
@@ -206,6 +207,7 @@ pub(crate) fn h_tp_1(t: f64, p: f64) -> f64 {
 /// Returns the region-1 specific volume
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
+#[inline]
 pub(crate) fn v_tp_1(t: f64, p: f64) -> f64 {
     // The multiplication by 1000 is necessary to convert R from kJ/kg.K to J/kg.K
     ((constants::_R * 1000.0) * t / p) * pi_1(p) * gamma_pi_1(t, p)
@@ -214,6 +216,7 @@ pub(crate) fn v_tp_1(t: f64, p: f64) -> f64 {
 /// Returns the region-1 specific internal energy
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
+#[inline]
 pub(crate) fn u_tp_1(t: f64, p: f64) -> f64 {
     constants::_R * t * (tau_1(t) * gamma_tau_1(t, p) - pi_1(p) * gamma_pi_1(t, p))
 }
@@ -221,6 +224,7 @@ pub(crate) fn u_tp_1(t: f64, p: f64) -> f64 {
 /// Returns the region-1 specific internal energy
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
+#[inline]
 pub(crate) fn s_tp_1(t: f64, p: f64) -> f64 {
     constants::_R * (tau_1(t) * gamma_tau_1(t, p) - gamma_1(t, p))
 }
@@ -228,6 +232,7 @@ pub(crate) fn s_tp_1(t: f64, p: f64) -> f64 {
 /// Returns the region-1 specific isobaric heat capacity
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
+#[inline]
 pub(crate) fn cp_tp_1(t: f64, p: f64) -> f64 {
     let tau = tau_1(t);
     constants::_R * (-tau.powi(2) * gamma_tau_tau_1(t, p))
@@ -236,6 +241,7 @@ pub(crate) fn cp_tp_1(t: f64, p: f64) -> f64 {
 /// Returns the region-1 specific isochoric heat capacity
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
+#[inline]
 pub(crate) fn cv_tp_1(t: f64, p: f64) -> f64 {
     let tau = tau_1(t);
     let corr = (gamma_pi_1(t, p) - tau * gamma_pi_tau_1(t, p)).powi(2) / gamma_pi_pi_1(t, p);
@@ -245,6 +251,7 @@ pub(crate) fn cv_tp_1(t: f64, p: f64) -> f64 {
 /// Returns the region-1 speed of sound
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
+#[inline]
 pub(crate) fn w_tp_1(t: f64, p: f64) -> f64 {
     let tau = tau_1(t);
     let gamma_pi = gamma_pi_1(t, p);
@@ -282,7 +289,7 @@ fn sigma_1_back(s: f64) -> f64 {
 /// Returns the region-1 backward correlation for T(p,s)
 /// Entropy is assumed to be in kJ/kg.K
 /// Pressure is assumed to be in Pa
-#[allow(dead_code)]
+#[inline]
 pub fn t_ps_1(p: f64, s: f64) -> f64 {
     let sig = sigma_1_back(s);
     let pi = pi_1_back(p);
@@ -299,7 +306,7 @@ pub fn t_ps_1(p: f64, s: f64) -> f64 {
 /// Returns the region-1 backward correlation for T(p,h)
 /// Enthalpy is assumed to be in kJ/kg
 /// Pressure is assumed to be in Pa
-#[allow(dead_code)]
+#[inline]
 pub fn t_ph_1(p: f64, h: f64) -> f64 {
     let eta = eta_1_back(h);
     let pi = pi_1_back(p);

--- a/src/iapws97/region_1.rs
+++ b/src/iapws97/region_1.rs
@@ -183,6 +183,7 @@ fn gamma_pi_tau_1(t: f64, p: f64) -> f64 {
 /// Returns the region-1 tau
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
+#[inline(always)]
 fn tau_1(t: f64) -> f64 {
     1386.0 / t
 }
@@ -190,6 +191,7 @@ fn tau_1(t: f64) -> f64 {
 /// Returns the region-1 pi
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
+#[inline(always)]
 fn pi_1(p: f64) -> f64 {
     p / (16.53e6)
 }
@@ -258,18 +260,21 @@ pub(crate) fn w_tp_1(t: f64, p: f64) -> f64 {
 
 /// Returns the region-1 eta for backwards calculations
 /// Enthalpy is assumed to be in kJ/kg
+#[inline(always)]
 fn eta_1_back(h: f64) -> f64 {
     h / 2500.0
 }
 
 /// Returns the region-1 pi for backwards calculations
 /// Pressure is assumed to be in Pa
+#[inline(always)]
 fn pi_1_back(p: f64) -> f64 {
     p / 1e6
 }
 
 /// Returns the region-1 sigma for backwards calculations
 /// Entropy is assumed to be in kJ/kg.K
+#[inline(always)]
 fn sigma_1_back(s: f64) -> f64 {
     s
 }

--- a/src/iapws97/region_1.rs
+++ b/src/iapws97/region_1.rs
@@ -1,4 +1,5 @@
 use crate::iapws97::constants;
+#[cfg(feature = "nightly")]
 use std::simd::prelude::*;
 
 const REGION_1_COEFFS_II: [i32; 34] = [
@@ -116,7 +117,8 @@ const REGION_1_BACK_COEFFS_PS_NI: [f64; 20] = [
 fn gamma_1(t: f64, p: f64) -> f64 {
     let tau = tau_1(t);
     let pi = pi_1(p);
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (tau, pi): ([f64; 34], [f64; 34]) = (
             std::array::from_fn(|x| (tau - 1.222).powi(REGION_1_COEFFS_JI[x])),
             std::array::from_fn(|x| (7.1 - pi).powi(REGION_1_COEFFS_II[x])),
@@ -125,7 +127,9 @@ fn gamma_1(t: f64, p: f64) -> f64 {
         let tau = Simd::<f64, 64>::load_or_default(&tau);
         let pi = Simd::<f64, 64>::load_or_default(&pi);
         (ni * tau * pi).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let mut sum = 0.0;
         for x in 0..REGION_1_COEFFS_II.len() {
             let ii = REGION_1_COEFFS_II[x];
@@ -143,7 +147,8 @@ fn gamma_1(t: f64, p: f64) -> f64 {
 fn gamma_pi_1(t: f64, p: f64) -> f64 {
     let tau = tau_1(t);
     let pi = pi_1(p);
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (tau, pi): ([f64; 34], [f64; 34]) = (
             std::array::from_fn(|x| (tau - 1.222).powi(REGION_1_COEFFS_JI[x])),
             std::array::from_fn(|x| (7.1 - pi).powi(REGION_1_COEFFS_II[x] - 1)),
@@ -153,7 +158,9 @@ fn gamma_pi_1(t: f64, p: f64) -> f64 {
         let tau = Simd::<f64, 64>::load_or_default(&tau);
         let pi = Simd::<f64, 64>::load_or_default(&pi);
         (-ni * ii * tau * pi).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let mut sum = 0.0;
         for x in 0..REGION_1_COEFFS_II.len() {
             let ii = REGION_1_COEFFS_II[x];
@@ -171,9 +178,8 @@ fn gamma_pi_1(t: f64, p: f64) -> f64 {
 fn gamma_pi_pi_1(t: f64, p: f64) -> f64 {
     let tau = tau_1(t);
     let pi = pi_1(p);
-    if cfg!(feature = "nightly") {
-        let tau = tau_1(t);
-        let pi = pi_1(p);
+    #[cfg(feature = "nightly")]
+    {
         let (tau, pi): ([f64; 34], [f64; 34]) = (
             std::array::from_fn(|x| (tau - 1.222).powi(REGION_1_COEFFS_JI[x])),
             std::array::from_fn(|x| (7.1 - pi).powi(REGION_1_COEFFS_II[x] - 2)),
@@ -183,7 +189,9 @@ fn gamma_pi_pi_1(t: f64, p: f64) -> f64 {
         let tau = Simd::<f64, 64>::load_or_default(&tau);
         let pi = Simd::<f64, 64>::load_or_default(&pi);
         (ni * ii * (ii - f64x64::splat(1.0)) * tau * pi).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let mut sum = 0.0;
         for x in 0..REGION_1_COEFFS_II.len() {
             let ii = REGION_1_COEFFS_II[x];
@@ -201,9 +209,8 @@ fn gamma_pi_pi_1(t: f64, p: f64) -> f64 {
 fn gamma_tau_1(t: f64, p: f64) -> f64 {
     let tau = tau_1(t);
     let pi = pi_1(p);
-    if cfg!(feature = "nightly") {
-        let tau = tau_1(t);
-        let pi = pi_1(p);
+    #[cfg(feature = "nightly")]
+    {
         let (tau, pi): ([f64; 34], [f64; 34]) = (
             std::array::from_fn(|x| (tau - 1.222).powi(REGION_1_COEFFS_JI[x] - 1)),
             std::array::from_fn(|x| (7.1 - pi).powi(REGION_1_COEFFS_II[x])),
@@ -213,7 +220,9 @@ fn gamma_tau_1(t: f64, p: f64) -> f64 {
         let tau = Simd::<f64, 64>::load_or_default(&tau);
         let pi = Simd::<f64, 64>::load_or_default(&pi);
         (ni * ji * tau * pi).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let mut sum = 0.0;
         for x in 0..REGION_1_COEFFS_II.len() {
             let ii = REGION_1_COEFFS_II[x];
@@ -231,9 +240,8 @@ fn gamma_tau_1(t: f64, p: f64) -> f64 {
 fn gamma_tau_tau_1(t: f64, p: f64) -> f64 {
     let tau = tau_1(t);
     let pi = pi_1(p);
-    if cfg!(feature = "nightly") {
-        let tau = tau_1(t);
-        let pi = pi_1(p);
+    #[cfg(feature = "nightly")]
+    {
         let (tau, pi): ([f64; 34], [f64; 34]) = (
             std::array::from_fn(|x| (tau - 1.222).powi(REGION_1_COEFFS_JI[x] - 2)),
             std::array::from_fn(|x| (7.1 - pi).powi(REGION_1_COEFFS_II[x])),
@@ -243,7 +251,9 @@ fn gamma_tau_tau_1(t: f64, p: f64) -> f64 {
         let tau = Simd::<f64, 64>::load_or_default(&tau);
         let pi = Simd::<f64, 64>::load_or_default(&pi);
         (ni * ji * (ji - f64x64::splat(1.0)) * tau * pi).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let mut sum = 0.0;
         for x in 0..REGION_1_COEFFS_II.len() {
             let ii = REGION_1_COEFFS_II[x];
@@ -261,7 +271,8 @@ fn gamma_tau_tau_1(t: f64, p: f64) -> f64 {
 fn gamma_pi_tau_1(t: f64, p: f64) -> f64 {
     let tau = tau_1(t);
     let pi = pi_1(p);
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (tau, pi): ([f64; 34], [f64; 34]) = (
             std::array::from_fn(|x| (tau - 1.222).powi(REGION_1_COEFFS_JI[x] - 1)),
             std::array::from_fn(|x| (7.1 - pi).powi(REGION_1_COEFFS_II[x] - 1)),
@@ -272,7 +283,9 @@ fn gamma_pi_tau_1(t: f64, p: f64) -> f64 {
         let tau = Simd::<f64, 64>::load_or_default(&tau);
         let pi = Simd::<f64, 64>::load_or_default(&pi);
         (-ni * ii * ji * tau * pi).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let mut sum = 0.0;
         for x in 0..REGION_1_COEFFS_II.len() {
             let ii = REGION_1_COEFFS_II[x];
@@ -397,9 +410,8 @@ fn sigma_1_back(s: f64) -> f64 {
 pub fn t_ps_1(p: f64, s: f64) -> f64 {
     let sig = sigma_1_back(s);
     let pi = pi_1_back(p);
-    if cfg!(feature = "nightly") {
-        let sig = sigma_1_back(s);
-        let pi = pi_1_back(p);
+    #[cfg(feature = "nightly")]
+    {
         let (sig, pi): ([f64; 20], [f64; 20]) = (
             std::array::from_fn(|x| (sig + 2.0).powi(REGION_1_BACK_COEFFS_PS_JI[x])),
             std::array::from_fn(|x| pi.powi(REGION_1_BACK_COEFFS_PS_II[x])),
@@ -408,7 +420,9 @@ pub fn t_ps_1(p: f64, s: f64) -> f64 {
         let sig = Simd::<f64, 32>::load_or_default(&sig);
         let pi = Simd::<f64, 32>::load_or_default(&pi);
         (ni * sig * pi).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let mut sum = 0.0;
         for x in 0..REGION_1_BACK_COEFFS_PS_II.len() {
             let ii = REGION_1_BACK_COEFFS_PS_II[x];
@@ -427,9 +441,8 @@ pub fn t_ps_1(p: f64, s: f64) -> f64 {
 pub fn t_ph_1(p: f64, h: f64) -> f64 {
     let eta = eta_1_back(h);
     let pi = pi_1_back(p);
-    if cfg!(feature = "nightly") {
-        let eta = eta_1_back(h);
-        let pi = pi_1_back(p);
+    #[cfg(feature = "nightly")]
+    {
         let (eta, pi): ([f64; 20], [f64; 20]) = (
             std::array::from_fn(|x| (eta + 1.0).powi(REGION_1_BACK_COEFFS_PH_JI[x])),
             std::array::from_fn(|x| pi.powi(REGION_1_BACK_COEFFS_PH_II[x])),
@@ -438,7 +451,9 @@ pub fn t_ph_1(p: f64, h: f64) -> f64 {
         let eta = Simd::<f64, 32>::load_or_default(&eta);
         let pi = Simd::<f64, 32>::load_or_default(&pi);
         (ni * eta * pi).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let mut sum = 0.0;
         for x in 0..REGION_1_BACK_COEFFS_PH_II.len() {
             let ii = REGION_1_BACK_COEFFS_PH_II[x];

--- a/src/iapws97/region_2.rs
+++ b/src/iapws97/region_2.rs
@@ -227,6 +227,7 @@ fn gamma_pi_tau_2_res(t: f64, p: f64) -> f64 {
 /// Returns the region-2 specific volume
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
+#[inline]
 pub(crate) fn v_tp_2(t: f64, p: f64) -> f64 {
     ((constants::_R * 1000.0) * t / p) * pi_2(p) * (gamma_pi_2_ideal(t, p) + gamma_pi_2_res(t, p))
 }
@@ -234,6 +235,7 @@ pub(crate) fn v_tp_2(t: f64, p: f64) -> f64 {
 /// Returns the region-2 enthalpy
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
+#[inline]
 pub(crate) fn h_tp_2(t: f64, p: f64) -> f64 {
     constants::_R * t * tau_2(t) * (gamma_tau_2_ideal(t, p) + gamma_tau_2_res(t, p))
 }
@@ -241,6 +243,7 @@ pub(crate) fn h_tp_2(t: f64, p: f64) -> f64 {
 /// Returns the region-2 internal energy
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
+#[inline]
 pub(crate) fn u_tp_2(t: f64, p: f64) -> f64 {
     let tau = tau_2(t);
     let pi = pi_2(p);
@@ -252,6 +255,7 @@ pub(crate) fn u_tp_2(t: f64, p: f64) -> f64 {
 /// Returns the region-2 entropy
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
+#[inline]
 pub(crate) fn s_tp_2(t: f64, p: f64) -> f64 {
     let tau = tau_2(t);
     let tau_term = gamma_tau_2_ideal(t, p) + gamma_tau_2_res(t, p);
@@ -262,6 +266,7 @@ pub(crate) fn s_tp_2(t: f64, p: f64) -> f64 {
 /// Returns the region-2 isobaric specific heat
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
+#[inline]
 pub(crate) fn cp_tp_2(t: f64, p: f64) -> f64 {
     let tau = tau_2(t);
     -constants::_R * tau.powi(2) * (gamma_tau_tau_2_ideal(t, p) + gamma_tau_tau_2_res(t, p))
@@ -270,6 +275,7 @@ pub(crate) fn cp_tp_2(t: f64, p: f64) -> f64 {
 /// Returns the region-2 isochoric specific heat
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
+#[inline]
 pub(crate) fn cv_tp_2(t: f64, p: f64) -> f64 {
     let tau = tau_2(t);
     let pi = pi_2(p);
@@ -281,6 +287,7 @@ pub(crate) fn cv_tp_2(t: f64, p: f64) -> f64 {
 /// Returns the region-2 sound velocity
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
+#[inline]
 pub(crate) fn w_tp_2(t: f64, p: f64) -> f64 {
     let tau = tau_2(t);
     let pi = pi_2(p);
@@ -291,7 +298,6 @@ pub(crate) fn w_tp_2(t: f64, p: f64) -> f64 {
     ((constants::_R * 1000.0 * t) * num / den).sqrt()
 }
 
-#[allow(dead_code)]
 fn t_ps_2a(pi: f64, s: f64) -> f64 {
     let i: [f64; 46] = [
         -1.5, -1.5, -1.5, -1.5, -1.5, -1.5, -1.25, -1.25, -1.25, -1.0, -1.0, -1.0, -1.0, -1.0,
@@ -360,7 +366,6 @@ fn t_ps_2a(pi: f64, s: f64) -> f64 {
         .sum()
 }
 
-#[allow(dead_code)]
 fn t_ps_2b(pi: f64, s: f64) -> f64 {
     let i: [i32; 44] = [
         -6, -6, -5, -5, -4, -4, -4, -3, -3, -3, -3, -2, -2, -2, -2, -1, -1, -1, -1, -1, 0, 0, 0, 0,
@@ -425,7 +430,6 @@ fn t_ps_2b(pi: f64, s: f64) -> f64 {
         .sum()
 }
 
-#[allow(dead_code)]
 fn t_ps_2c(pi: f64, s: f64) -> f64 {
     let i: [i32; 30] = [
         -2, -2, -1, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 7, 7, 7, 7, 7,
@@ -476,7 +480,7 @@ fn t_ps_2c(pi: f64, s: f64) -> f64 {
 /// Returns the region-1 backward correlation for T(p,s)
 /// Entropy is assumed to be in kJ/kg.K
 /// Pressure is assumed to be in Pa
-#[allow(dead_code)]
+#[inline]
 pub fn t_ps_2(p: f64, s: f64) -> f64 {
     let pi = p / 1e6;
 
@@ -487,7 +491,6 @@ pub fn t_ps_2(p: f64, s: f64) -> f64 {
     }
 }
 
-#[allow(dead_code)]
 fn t_ph_2a(pi: f64, eta: f64) -> f64 {
     let i: [i32; 34] = [
         0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 4, 4, 4, 5, 5,
@@ -541,7 +544,6 @@ fn t_ph_2a(pi: f64, eta: f64) -> f64 {
         .sum()
 }
 
-#[allow(dead_code)]
 fn t_ph_2b(pi: f64, eta: f64) -> f64 {
     let i: [i32; 38] = [
         0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4,
@@ -600,7 +602,6 @@ fn t_ph_2b(pi: f64, eta: f64) -> f64 {
         .sum()
 }
 
-#[allow(dead_code)]
 fn t_ph_2c(pi: f64, eta: f64) -> f64 {
     let i: [i32; 23] = [
         -7, -7, -6, -6, -5, -5, -2, -2, -1, -1, 0, 0, 1, 1, 2, 6, 6, 6, 6, 6, 6, 6, 6,
@@ -644,7 +645,7 @@ fn t_ph_2c(pi: f64, eta: f64) -> f64 {
 /// Returns the region-2 back calculated T(p,h)
 /// Pressure is assumed to be in Pa
 /// Enthalpy is assumed to be in kJ/kg
-#[allow(dead_code)]
+#[inline]
 pub fn t_ph_2(p: f64, h: f64) -> f64 {
     let pi = p / 1e6;
     let eta = h / 2.0e3;

--- a/src/iapws97/region_2.rs
+++ b/src/iapws97/region_2.rs
@@ -64,6 +64,7 @@ const REGION_2_COEFFS_IDEAL: [[f64; 2]; 9] = [
 /// Returns the region-2 tau
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
+#[inline(always)]
 fn tau_2(t: f64) -> f64 {
     540.0 / t
 }
@@ -71,6 +72,7 @@ fn tau_2(t: f64) -> f64 {
 /// Returns the region-2 pi
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
+#[inline(always)]
 fn pi_2(p: f64) -> f64 {
     p / 1e6
 }
@@ -137,6 +139,7 @@ fn gamma_tau_tau_2_ideal(t: f64, _: f64) -> f64 {
 /// Returns the region-2 ideal gamma_pi
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
+#[inline(always)]
 fn gamma_pi_2_ideal(_: f64, p: f64) -> f64 {
     1.0 / pi_2(p)
 }

--- a/src/iapws97/region_2.rs
+++ b/src/iapws97/region_2.rs
@@ -547,6 +547,7 @@ fn t_ps_2b(pi: f64, s: f64) -> f64 {
     // Calculate T
     if cfg!(feature = "nightly") {
         let (eta, pi): ([f64; 44], [f64; 44]) = (
+            #[allow(clippy::approx_constant)]
             std::array::from_fn(|x| (10.0 - s / 0.7853).powi(j[x])),
             std::array::from_fn(|x| pi.powi(i[x])),
         );

--- a/src/iapws97/region_2.rs
+++ b/src/iapws97/region_2.rs
@@ -1,62 +1,74 @@
 // Region 2
 use crate::iapws97::constants;
 
-const REGION_2_COEFFS_RES: [[f64; 3]; 43] = [
-    [1.0, 0.0, -0.0017731742473213],
-    [1.0, 1.0, -0.017834862292358],
-    [1.0, 2.0, -0.045996013696365],
-    [1.0, 3.0, -0.057581259083432],
-    [1.0, 6.0, -0.05032527872793],
-    [2.0, 1.0, -0.000033032641670203],
-    [2.0, 2.0, -0.00018948987516315],
-    [2.0, 4.0, -0.0039392777243355],
-    [2.0, 7.0, -0.043797295650573],
-    [2.0, 36.0, -0.000026674547914087],
-    [3.0, 0.0, 2.0481737692309E-08],
-    [3.0, 1.0, 4.3870667284435E-07],
-    [3.0, 3.0, -0.00003227767723857],
-    [3.0, 6.0, -0.0015033924542148],
-    [3.0, 35.0, -0.040668253562649],
-    [4.0, 1.0, -7.8847309559367E-10],
-    [4.0, 2.0, 1.2790717852285E-08],
-    [4.0, 3.0, 4.8225372718507E-07],
-    [5.0, 7.0, 2.2922076337661E-06],
-    [6.0, 3.0, -1.6714766451061E-11],
-    [6.0, 16.0, -0.0021171472321355],
-    [6.0, 35.0, -23.895741934104],
-    [7.0, 0.0, -5.905956432427E-18],
-    [7.0, 11.0, -1.2621808899101E-06],
-    [7.0, 25.0, -0.038946842435739],
-    [8.0, 8.0, 1.1256211360459E-11],
-    [8.0, 36.0, -8.2311340897998],
-    [9.0, 13.0, 1.9809712802088E-08],
-    [10.0, 4.0, 1.0406965210174E-19],
-    [10.0, 10.0, -1.0234747095929E-13],
-    [10.0, 14.0, -1.0018179379511E-09],
-    [16.0, 29.0, -8.0882908646985E-11],
-    [16.0, 50.0, 0.10693031879409],
-    [18.0, 57.0, -0.33662250574171],
-    [20.0, 20.0, 8.9185845355421E-25],
-    [20.0, 35.0, 3.0629316876232E-13],
-    [20.0, 48.0, -4.2002467698208E-06],
-    [21.0, 21.0, -5.9056029685639E-26],
-    [22.0, 53.0, 3.7826947613457E-06],
-    [23.0, 39.0, -1.2768608934681E-15],
-    [24.0, 26.0, 7.3087610595061E-29],
-    [24.0, 40.0, 5.5414715350778E-17],
-    [24.0, 58.0, -9.436970724121E-07],
+const REGION_2_COEFFS_II_RES: [i32; 43] = [
+    1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 5, 6, 6, 6, 7, 7, 7, 8, 8, 9, 10, 10, 10,
+    16, 16, 18, 20, 20, 20, 21, 22, 23, 24, 24, 24,
 ];
 
-const REGION_2_COEFFS_IDEAL: [[f64; 2]; 9] = [
-    [0.0, -0.96927686500217e1],
-    [1.0, 0.10086655968018e2],
-    [-5.0, -0.56087911283020e-2],
-    [-4.0, 0.71452738081455e-1],
-    [-3.0, -0.40710498223928],
-    [-2.0, 0.14240819171444e1],
-    [-1.0, -0.43839511319450e1],
-    [2.0, -0.28408632460772],
-    [3.0, 0.21268463753307e-1],
+const REGION_2_COEFFS_JI_RES: [i32; 43] = [
+    0, 1, 2, 3, 6, 1, 2, 4, 7, 36, 0, 1, 3, 6, 35, 1, 2, 3, 7, 3, 16, 35, 0, 11, 25, 8, 36, 13, 4,
+    10, 14, 29, 50, 57, 20, 35, 48, 21, 53, 39, 26, 40, 58,
+];
+
+const REGION_2_COEFFS_NI_RES: [f64; 43] = [
+    -0.0017731742473213,
+    -0.017834862292358,
+    -0.045996013696365,
+    -0.057581259083432,
+    -0.05032527872793,
+    -0.000033032641670203,
+    -0.00018948987516315,
+    -0.0039392777243355,
+    -0.043797295650573,
+    -0.000026674547914087,
+    2.0481737692309E-08,
+    4.3870667284435E-07,
+    -0.00003227767723857,
+    -0.0015033924542148,
+    -0.040668253562649,
+    -7.8847309559367E-10,
+    1.2790717852285E-08,
+    4.8225372718507E-07,
+    2.2922076337661E-06,
+    -1.6714766451061E-11,
+    -0.0021171472321355,
+    -23.895741934104,
+    -5.905956432427E-18,
+    -1.2621808899101E-06,
+    -0.038946842435739,
+    1.1256211360459E-11,
+    -8.2311340897998,
+    1.9809712802088E-08,
+    1.0406965210174E-19,
+    -1.0234747095929E-13,
+    -1.0018179379511E-09,
+    -8.0882908646985E-11,
+    0.10693031879409,
+    -0.33662250574171,
+    8.9185845355421E-25,
+    3.0629316876232E-13,
+    -4.2002467698208E-06,
+    -5.9056029685639E-26,
+    3.7826947613457E-06,
+    -1.2768608934681E-15,
+    7.3087610595061E-29,
+    5.5414715350778E-17,
+    -9.436970724121E-07,
+];
+
+const REGION_2_COEFFS_JI_IDEAL: [i32; 9] = [0, 1, -5, -4, -3, -2, -1, 2, 3];
+
+const REGION_2_COEFFS_NI_IDEAL: [f64; 9] = [
+    -0.96927686500217e1,
+    0.10086655968018e2,
+    -0.56087911283020e-2,
+    0.71452738081455e-1,
+    -0.40710498223928,
+    0.14240819171444e1,
+    -0.43839511319450e1,
+    -0.28408632460772,
+    0.21268463753307e-1,
 ];
 
 // ================    Region 2 ===================
@@ -66,7 +78,7 @@ const REGION_2_COEFFS_IDEAL: [[f64; 2]; 9] = [
 /// Pressure is assumed to be in Pa
 #[inline(always)]
 fn tau_2(t: f64) -> f64 {
-    540.0 / t
+    540.0_f64 / t
 }
 
 /// Returns the region-2 pi
@@ -81,13 +93,13 @@ fn pi_2(p: f64) -> f64 {
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
 fn gamma_2_ideal(t: f64, p: f64) -> f64 {
-    let pi = pi_2(p);
-    let mut sum: f64 = 0.0;
     let tau = tau_2(t);
-    for coefficient in REGION_2_COEFFS_IDEAL {
-        let ji = coefficient[0];
-        let ni = coefficient[1];
-        sum += ni * tau.powf(ji);
+    let pi = pi_2(p);
+    let mut sum = 0.0_f64;
+    for x in 0..REGION_2_COEFFS_JI_IDEAL.len() {
+        let ji = REGION_2_COEFFS_JI_IDEAL[x];
+        let ni = REGION_2_COEFFS_NI_IDEAL[x];
+        sum += ni * tau.powi(ji);
     }
     pi.ln() + sum
 }
@@ -96,13 +108,13 @@ fn gamma_2_ideal(t: f64, p: f64) -> f64 {
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
 fn gamma_2_res(t: f64, p: f64) -> f64 {
-    let pi = pi_2(p);
-    let mut sum: f64 = 0.0;
     let tau = tau_2(t);
-    for coefficient in REGION_2_COEFFS_RES {
-        let ii = coefficient[0] as i32;
-        let ji = coefficient[1] as i32;
-        let ni = coefficient[2];
+    let pi = pi_2(p);
+    let mut sum = 0.0_f64;
+    for x in 0..REGION_2_COEFFS_II_RES.len() {
+        let ii = REGION_2_COEFFS_II_RES[x];
+        let ji = REGION_2_COEFFS_JI_RES[x];
+        let ni = REGION_2_COEFFS_NI_RES[x];
         sum += ni * pi.powi(ii) * (tau - 0.5).powi(ji);
     }
     sum
@@ -112,12 +124,12 @@ fn gamma_2_res(t: f64, p: f64) -> f64 {
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
 fn gamma_tau_2_ideal(t: f64, _: f64) -> f64 {
-    let mut sum: f64 = 0.0;
     let tau = tau_2(t);
-    for coefficient in REGION_2_COEFFS_IDEAL {
-        let ji = coefficient[0];
-        let ni = coefficient[1];
-        sum += ni * ji * tau.powf(ji - 1.0);
+    let mut sum = 0.0_f64;
+    for x in 0..REGION_2_COEFFS_JI_IDEAL.len() {
+        let ji = REGION_2_COEFFS_JI_IDEAL[x];
+        let ni = REGION_2_COEFFS_NI_IDEAL[x];
+        sum += ni * ji as f64 * tau.powi(ji - 1);
     }
     sum
 }
@@ -126,12 +138,12 @@ fn gamma_tau_2_ideal(t: f64, _: f64) -> f64 {
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
 fn gamma_tau_tau_2_ideal(t: f64, _: f64) -> f64 {
-    let mut sum: f64 = 0.0;
     let tau = tau_2(t);
-    for coefficient in REGION_2_COEFFS_IDEAL {
-        let ji = coefficient[0];
-        let ni = coefficient[1];
-        sum += ni * ji * (ji - 1.0) * tau.powf(ji - 2.0);
+    let mut sum = 0.0_f64;
+    for x in 0..REGION_2_COEFFS_JI_IDEAL.len() {
+        let ji = REGION_2_COEFFS_JI_IDEAL[x];
+        let ni = REGION_2_COEFFS_NI_IDEAL[x];
+        sum += ni * (ji * (ji - 1)) as f64 * tau.powi(ji - 2);
     }
     sum
 }
@@ -141,20 +153,20 @@ fn gamma_tau_tau_2_ideal(t: f64, _: f64) -> f64 {
 /// Pressure is assumed to be in Pa
 #[inline(always)]
 fn gamma_pi_2_ideal(_: f64, p: f64) -> f64 {
-    1.0 / pi_2(p)
+    1.0_f64 / pi_2(p)
 }
 
 /// Returns the region-2 residual gamma_tau
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
 fn gamma_tau_2_res(t: f64, p: f64) -> f64 {
-    let mut sum: f64 = 0.0;
     let tau = tau_2(t);
     let pi = pi_2(p);
-    for coefficient in REGION_2_COEFFS_RES {
-        let ii = coefficient[0] as i32;
-        let ji = coefficient[1] as i32;
-        let ni = coefficient[2];
+    let mut sum = 0.0_f64;
+    for x in 0..REGION_2_COEFFS_II_RES.len() {
+        let ii = REGION_2_COEFFS_II_RES[x];
+        let ji = REGION_2_COEFFS_JI_RES[x];
+        let ni = REGION_2_COEFFS_NI_RES[x];
         sum += ni * pi.powi(ii) * f64::from(ji) * (tau - 0.5).powi(ji - 1);
     }
     sum
@@ -164,14 +176,14 @@ fn gamma_tau_2_res(t: f64, p: f64) -> f64 {
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
 fn gamma_tau_tau_2_res(t: f64, p: f64) -> f64 {
-    let mut sum: f64 = 0.0;
     let tau = tau_2(t);
     let pi = pi_2(p);
-    for coefficient in REGION_2_COEFFS_RES {
-        let ii = coefficient[0] as i32;
-        let ji = coefficient[1] as i32;
-        let ni = coefficient[2];
-        sum += ni * pi.powi(ii) * f64::from(ji * (ji - 1)) * (tau - 0.5).powi(ji - 2);
+    let mut sum = 0.0_f64;
+    for x in 0..REGION_2_COEFFS_II_RES.len() {
+        let ii = REGION_2_COEFFS_II_RES[x];
+        let ji = REGION_2_COEFFS_JI_RES[x];
+        let ni = REGION_2_COEFFS_NI_RES[x];
+        sum += ni * pi.powi(ii) * (ji * (ji - 1)) as f64 * (tau - 0.5).powi(ji - 2);
     }
     sum
 }
@@ -180,14 +192,14 @@ fn gamma_tau_tau_2_res(t: f64, p: f64) -> f64 {
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
 fn gamma_pi_2_res(t: f64, p: f64) -> f64 {
-    let mut sum: f64 = 0.0;
     let tau = tau_2(t);
     let pi = pi_2(p);
-    for coefficient in REGION_2_COEFFS_RES {
-        let ii = coefficient[0] as i32;
-        let ji = coefficient[1] as i32;
-        let ni = coefficient[2];
-        sum += ni * pi.powi(ii - 1) * f64::from(ii) * (tau - 0.5).powi(ji);
+    let mut sum = 0.0_f64;
+    for x in 0..REGION_2_COEFFS_II_RES.len() {
+        let ii = REGION_2_COEFFS_II_RES[x];
+        let ji = REGION_2_COEFFS_JI_RES[x];
+        let ni = REGION_2_COEFFS_NI_RES[x];
+        sum += ni * pi.powi(ii - 1) * ii as f64 * (tau - 0.5).powi(ji);
     }
     sum
 }
@@ -196,14 +208,14 @@ fn gamma_pi_2_res(t: f64, p: f64) -> f64 {
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
 fn gamma_pi_pi_2_res(t: f64, p: f64) -> f64 {
-    let mut sum: f64 = 0.0;
     let tau = tau_2(t);
     let pi = pi_2(p);
-    for coefficient in REGION_2_COEFFS_RES {
-        let ii = coefficient[0] as i32;
-        let ji = coefficient[1] as i32;
-        let ni = coefficient[2];
-        sum += ni * pi.powi(ii - 2) * f64::from(ii * (ii - 1)) * (tau - 0.5).powi(ji);
+    let mut sum = 0.0_f64;
+    for x in 0..REGION_2_COEFFS_II_RES.len() {
+        let ii = REGION_2_COEFFS_II_RES[x];
+        let ji = REGION_2_COEFFS_JI_RES[x];
+        let ni = REGION_2_COEFFS_NI_RES[x];
+        sum += ni * pi.powi(ii - 2) * (ii * (ii - 1)) as f64 * (tau - 0.5).powi(ji);
     }
     sum
 }
@@ -212,14 +224,14 @@ fn gamma_pi_pi_2_res(t: f64, p: f64) -> f64 {
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
 fn gamma_pi_tau_2_res(t: f64, p: f64) -> f64 {
-    let mut sum: f64 = 0.0;
     let tau = tau_2(t);
     let pi = pi_2(p);
-    for coefficient in REGION_2_COEFFS_RES {
-        let ii = coefficient[0] as i32;
-        let ji = coefficient[1] as i32;
-        let ni = coefficient[2];
-        sum += ni * pi.powi(ii - 1) * f64::from(ii * ji) * (tau - 0.5).powi(ji - 1);
+    let mut sum = 0.0_f64;
+    for x in 0..REGION_2_COEFFS_II_RES.len() {
+        let ii = REGION_2_COEFFS_II_RES[x];
+        let ji = REGION_2_COEFFS_JI_RES[x];
+        let ni = REGION_2_COEFFS_NI_RES[x];
+        sum += ni * pi.powi(ii - 1) * (ii * ji) as f64 * (tau - 0.5).powi(ji - 1);
     }
     sum
 }
@@ -229,7 +241,9 @@ fn gamma_pi_tau_2_res(t: f64, p: f64) -> f64 {
 /// Pressure is assumed to be in Pa
 #[inline]
 pub(crate) fn v_tp_2(t: f64, p: f64) -> f64 {
-    ((constants::_R * 1000.0) * t / p) * pi_2(p) * (gamma_pi_2_ideal(t, p) + gamma_pi_2_res(t, p))
+    ((constants::_R * 1000.0_f64) * t / p)
+        * pi_2(p)
+        * (gamma_pi_2_ideal(t, p) + gamma_pi_2_res(t, p))
 }
 
 /// Returns the region-2 enthalpy

--- a/src/iapws97/region_2.rs
+++ b/src/iapws97/region_2.rs
@@ -1,5 +1,6 @@
 // Region 2
 use crate::iapws97::constants;
+#[cfg(feature = "nightly")]
 use std::simd::prelude::*;
 
 const REGION_2_COEFFS_II_RES: [i32; 43] = [
@@ -96,12 +97,15 @@ fn pi_2(p: f64) -> f64 {
 fn gamma_2_ideal(t: f64, p: f64) -> f64 {
     let tau = tau_2(t);
     let pi = pi_2(p);
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let tau: [f64; 9] = std::array::from_fn(|x| tau.powi(REGION_2_COEFFS_JI_IDEAL[x]));
         let ni = Simd::<f64, 16>::load_or_default(&REGION_2_COEFFS_NI_IDEAL);
         let tau = Simd::<f64, 16>::load_or_default(&tau);
         (ni * tau).reduce_sum() + pi.ln()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let mut sum = 0.0_f64;
         for x in 0..REGION_2_COEFFS_JI_IDEAL.len() {
             let ji = REGION_2_COEFFS_JI_IDEAL[x];
@@ -118,7 +122,8 @@ fn gamma_2_ideal(t: f64, p: f64) -> f64 {
 fn gamma_2_res(t: f64, p: f64) -> f64 {
     let tau = tau_2(t);
     let pi = pi_2(p);
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (pi, tau): ([f64; 43], [f64; 43]) = (
             std::array::from_fn(|x| (tau - 0.5).powi(REGION_2_COEFFS_JI_RES[x])),
             std::array::from_fn(|x| pi.powi(REGION_2_COEFFS_II_RES[x])),
@@ -127,7 +132,9 @@ fn gamma_2_res(t: f64, p: f64) -> f64 {
         let tau = Simd::<f64, 64>::load_or_default(&tau);
         let pi = Simd::<f64, 64>::load_or_default(&pi);
         (ni * tau * pi).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let mut sum = 0.0_f64;
         for x in 0..REGION_2_COEFFS_II_RES.len() {
             let ii = REGION_2_COEFFS_II_RES[x];
@@ -144,13 +151,16 @@ fn gamma_2_res(t: f64, p: f64) -> f64 {
 /// Pressure is assumed to be in Pa
 fn gamma_tau_2_ideal(t: f64, _: f64) -> f64 {
     let tau = tau_2(t);
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let tau: [f64; 9] = std::array::from_fn(|x| tau.powi(REGION_2_COEFFS_JI_IDEAL[x] - 1));
         let ji = Simd::<i32, 16>::load_or_default(&REGION_2_COEFFS_JI_IDEAL).cast::<f64>();
         let ni = Simd::<f64, 16>::load_or_default(&REGION_2_COEFFS_NI_IDEAL);
         let tau = Simd::<f64, 16>::load_or_default(&tau);
         (ni * ji * tau).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let mut sum = 0.0_f64;
         for x in 0..REGION_2_COEFFS_JI_IDEAL.len() {
             let ji = REGION_2_COEFFS_JI_IDEAL[x];
@@ -166,13 +176,16 @@ fn gamma_tau_2_ideal(t: f64, _: f64) -> f64 {
 /// Pressure is assumed to be in Pa
 fn gamma_tau_tau_2_ideal(t: f64, _: f64) -> f64 {
     let tau = tau_2(t);
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let tau: [f64; 9] = std::array::from_fn(|x| tau.powi(REGION_2_COEFFS_JI_IDEAL[x] - 2));
         let ji = Simd::<i32, 16>::load_or_default(&REGION_2_COEFFS_JI_IDEAL).cast::<f64>();
         let ni = Simd::<f64, 16>::load_or_default(&REGION_2_COEFFS_NI_IDEAL);
         let tau = Simd::<f64, 16>::load_or_default(&tau);
         (ni * ji * (ji - f64x16::splat(1.0)) * tau).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let mut sum = 0.0_f64;
         for x in 0..REGION_2_COEFFS_JI_IDEAL.len() {
             let ji = REGION_2_COEFFS_JI_IDEAL[x];
@@ -197,7 +210,8 @@ fn gamma_pi_2_ideal(_: f64, p: f64) -> f64 {
 fn gamma_tau_2_res(t: f64, p: f64) -> f64 {
     let tau = tau_2(t);
     let pi = pi_2(p);
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (tau, pi): ([f64; 43], [f64; 43]) = (
             std::array::from_fn(|x| (tau - 0.5).powi(REGION_2_COEFFS_JI_RES[x] - 1)),
             std::array::from_fn(|x| pi.powi(REGION_2_COEFFS_II_RES[x])),
@@ -207,7 +221,9 @@ fn gamma_tau_2_res(t: f64, p: f64) -> f64 {
         let tau = Simd::<f64, 64>::load_or_default(&tau);
         let pi = Simd::<f64, 64>::load_or_default(&pi);
         (ni * ji * tau * pi).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let mut sum = 0.0_f64;
         for x in 0..REGION_2_COEFFS_II_RES.len() {
             let ii = REGION_2_COEFFS_II_RES[x];
@@ -225,7 +241,8 @@ fn gamma_tau_2_res(t: f64, p: f64) -> f64 {
 fn gamma_tau_tau_2_res(t: f64, p: f64) -> f64 {
     let tau = tau_2(t);
     let pi = pi_2(p);
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (tau, pi): ([f64; 43], [f64; 43]) = (
             std::array::from_fn(|x| (tau - 0.5).powi(REGION_2_COEFFS_JI_RES[x] - 2)),
             std::array::from_fn(|x| pi.powi(REGION_2_COEFFS_II_RES[x])),
@@ -235,7 +252,9 @@ fn gamma_tau_tau_2_res(t: f64, p: f64) -> f64 {
         let tau = Simd::<f64, 64>::load_or_default(&tau);
         let pi = Simd::<f64, 64>::load_or_default(&pi);
         (ni * ji * (ji - f64x64::splat(1.0)) * tau * pi).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let mut sum = 0.0_f64;
         for x in 0..REGION_2_COEFFS_II_RES.len() {
             let ii = REGION_2_COEFFS_II_RES[x];
@@ -253,7 +272,8 @@ fn gamma_tau_tau_2_res(t: f64, p: f64) -> f64 {
 fn gamma_pi_2_res(t: f64, p: f64) -> f64 {
     let tau = tau_2(t);
     let pi = pi_2(p);
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (tau, pi): ([f64; 43], [f64; 43]) = (
             std::array::from_fn(|x| (tau - 0.5).powi(REGION_2_COEFFS_JI_RES[x])),
             std::array::from_fn(|x| pi.powi(REGION_2_COEFFS_II_RES[x] - 1)),
@@ -263,7 +283,9 @@ fn gamma_pi_2_res(t: f64, p: f64) -> f64 {
         let tau = Simd::<f64, 64>::load_or_default(&tau);
         let pi = Simd::<f64, 64>::load_or_default(&pi);
         (ni * ii * tau * pi).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let mut sum = 0.0_f64;
         for x in 0..REGION_2_COEFFS_II_RES.len() {
             let ii = REGION_2_COEFFS_II_RES[x];
@@ -281,7 +303,8 @@ fn gamma_pi_2_res(t: f64, p: f64) -> f64 {
 fn gamma_pi_pi_2_res(t: f64, p: f64) -> f64 {
     let tau = tau_2(t);
     let pi = pi_2(p);
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (tau, pi): ([f64; 43], [f64; 43]) = (
             std::array::from_fn(|x| (tau - 0.5).powi(REGION_2_COEFFS_JI_RES[x])),
             std::array::from_fn(|x| pi.powi(REGION_2_COEFFS_II_RES[x] - 2)),
@@ -291,7 +314,9 @@ fn gamma_pi_pi_2_res(t: f64, p: f64) -> f64 {
         let tau = Simd::<f64, 64>::load_or_default(&tau);
         let pi = Simd::<f64, 64>::load_or_default(&pi);
         (ni * ii * (ii - f64x64::splat(1.0)) * tau * pi).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let mut sum = 0.0_f64;
         for x in 0..REGION_2_COEFFS_II_RES.len() {
             let ii = REGION_2_COEFFS_II_RES[x];
@@ -309,7 +334,8 @@ fn gamma_pi_pi_2_res(t: f64, p: f64) -> f64 {
 fn gamma_pi_tau_2_res(t: f64, p: f64) -> f64 {
     let tau = tau_2(t);
     let pi = pi_2(p);
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (tau, pi): ([f64; 43], [f64; 43]) = (
             std::array::from_fn(|x| (tau - 0.5).powi(REGION_2_COEFFS_JI_RES[x] - 1)),
             std::array::from_fn(|x| pi.powi(REGION_2_COEFFS_II_RES[x] - 1)),
@@ -320,7 +346,9 @@ fn gamma_pi_tau_2_res(t: f64, p: f64) -> f64 {
         let tau = Simd::<f64, 64>::load_or_default(&tau);
         let pi = Simd::<f64, 64>::load_or_default(&pi);
         (ni * ii * ji * tau * pi).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let mut sum = 0.0_f64;
         for x in 0..REGION_2_COEFFS_II_RES.len() {
             let ii = REGION_2_COEFFS_II_RES[x];
@@ -470,7 +498,8 @@ fn t_ps_2a(pi: f64, s: f64) -> f64 {
     ];
 
     // Calculate T
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (eta, pi): ([f64; 46], [f64; 46]) = (
             std::array::from_fn(|x| ((s / 2.0) - 2.0).powi(j[x])),
             std::array::from_fn(|x| pi.powf(i[x])),
@@ -480,7 +509,9 @@ fn t_ps_2a(pi: f64, s: f64) -> f64 {
         let pi = Simd::<f64, 64>::load_or_default(&pi);
 
         (n * eta * pi).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let x: [usize; 46] = core::array::from_fn(|i| i + 1);
         x.into_iter()
             .map(|x| n[x - 1] * pi.powf(i[x - 1]) * ((s / 2.0) - 2.0).powi(j[x - 1]))
@@ -545,7 +576,8 @@ fn t_ps_2b(pi: f64, s: f64) -> f64 {
     ];
 
     // Calculate T
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (eta, pi): ([f64; 44], [f64; 44]) = (
             #[allow(clippy::approx_constant)]
             std::array::from_fn(|x| (10.0 - s / 0.7853).powi(j[x])),
@@ -556,7 +588,9 @@ fn t_ps_2b(pi: f64, s: f64) -> f64 {
         let pi = Simd::<f64, 64>::load_or_default(&pi);
 
         (n * eta * pi).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let x: [usize; 44] = core::array::from_fn(|i| i + 1);
         #[allow(clippy::approx_constant)]
         x.into_iter()
@@ -606,7 +640,8 @@ fn t_ps_2c(pi: f64, s: f64) -> f64 {
     ];
 
     // Calculate T
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (eta, pi): ([f64; 30], [f64; 30]) = (
             std::array::from_fn(|x| (2.0 - (s / 2.9251)).powi(j[x])),
             std::array::from_fn(|x| pi.powi(i[x])),
@@ -616,7 +651,9 @@ fn t_ps_2c(pi: f64, s: f64) -> f64 {
         let pi = Simd::<f64, 64>::load_or_default(&pi);
 
         (n * eta * pi).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let x: [usize; 30] = core::array::from_fn(|i| i + 1);
         x.into_iter()
             .map(|x| n[x - 1] * pi.powi(i[x - 1]) * (2.0 - (s / 2.9251)).powi(j[x - 1]))
@@ -685,7 +722,8 @@ fn t_ph_2a(pi: f64, eta: f64) -> f64 {
     ];
 
     // Calculate T
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (eta, pi): ([f64; 34], [f64; 34]) = (
             std::array::from_fn(|x| (eta - 2.1).powi(j[x])),
             std::array::from_fn(|x| pi.powi(i[x])),
@@ -695,7 +733,9 @@ fn t_ph_2a(pi: f64, eta: f64) -> f64 {
         let pi = Simd::<f64, 64>::load_or_default(&pi);
 
         (n * eta * pi).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let x: [usize; 34] = core::array::from_fn(|i| i + 1);
         x.into_iter()
             .map(|x| n[x - 1] * pi.powi(i[x - 1]) * (eta - 2.1).powi(j[x - 1]))
@@ -754,7 +794,8 @@ fn t_ph_2b(pi: f64, eta: f64) -> f64 {
     ];
 
     // Calculate T
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (eta, pi): ([f64; 38], [f64; 38]) = (
             std::array::from_fn(|x| (eta - 2.6).powi(j[x])),
             std::array::from_fn(|x| (pi - 2.0).powi(i[x])),
@@ -764,7 +805,9 @@ fn t_ph_2b(pi: f64, eta: f64) -> f64 {
         let pi = Simd::<f64, 64>::load_or_default(&pi);
 
         (n * eta * pi).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let x: [usize; 38] = core::array::from_fn(|i| i + 1);
         x.into_iter()
             .map(|x| n[x - 1] * (pi - 2.0).powi(i[x - 1]) * (eta - 2.6).powi(j[x - 1]))
@@ -806,7 +849,8 @@ fn t_ph_2c(pi: f64, eta: f64) -> f64 {
     ];
 
     // Calculate T
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (eta, pi): ([f64; 23], [f64; 23]) = (
             std::array::from_fn(|x| (eta - 1.8).powi(j[x])),
             std::array::from_fn(|x| (pi + 25.0).powi(i[x])),
@@ -816,7 +860,9 @@ fn t_ph_2c(pi: f64, eta: f64) -> f64 {
         let pi = Simd::<f64, 32>::load_or_default(&pi);
 
         (n * eta * pi).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let x: [usize; 23] = core::array::from_fn(|i| i + 1);
         x.into_iter()
             .map(|x| n[x - 1] * (pi + 25.0).powi(i[x - 1]) * (eta - 1.8).powi(j[x - 1]))

--- a/src/iapws97/region_3.rs
+++ b/src/iapws97/region_3.rs
@@ -33,47 +33,57 @@ enum Region3 {
 
 // Region 3
 
-const REGION_3_COEFFS: [[f64; 3]; 40] = [
-    [0.0, 0.0, 0.10658070028513e1],
-    [0.0, 0.0, -0.15732845290239e2],
-    [0.0, 1.0, 0.20944396974307e2],
-    [0.0, 2.0, -0.76867707878716e1],
-    [0.0, 7.0, 0.26185947787954e1],
-    [0.0, 10.0, -0.28080781148620e1],
-    [0.0, 12.0, 0.12053369696517e1],
-    [0.0, 23.0, -0.84566812812502e-2],
-    [1.0, 2.0, -0.12654315477714e1],
-    [1.0, 6.0, -0.11524407806681e1],
-    [1.0, 15.0, 0.88521043984318],
-    [1.0, 17.0, -0.64207765181607],
-    [2.0, 0.0, 0.38493460186671],
-    [2.0, 2.0, -0.85214708824206],
-    [2.0, 6.0, 0.48972281541877e1],
-    [2.0, 7.0, -0.30502617256965e1],
-    [2.0, 22.0, 0.39420536879154e-1],
-    [2.0, 26.0, 0.12558408424308],
-    [3.0, 0.0, -0.27999329698710],
-    [3.0, 2.0, 0.13899799569460e1],
-    [3.0, 4.0, -0.20189915023570e1],
-    [3.0, 16.0, -0.82147637173963e-2],
-    [3.0, 26.0, -0.47596035734923],
-    [4.0, 0.0, 0.43984074473500e-1],
-    [4.0, 2.0, -0.44476435428739],
-    [4.0, 4.0, 0.90572070719733],
-    [4.0, 26.0, 0.70522450087967],
-    [5.0, 1.0, 0.10770512626332],
-    [5.0, 3.0, -0.32913623258954],
-    [5.0, 26.0, -0.50871062041158],
-    [6.0, 0.0, -0.22175400873096e-1],
-    [6.0, 2.0, 0.94260751665092e-1],
-    [6.0, 26.0, 0.16436278447961],
-    [7.0, 2.0, -0.13503372241348e-1],
-    [8.0, 26.0, -0.14834345352472e-1],
-    [9.0, 2.0, 0.57922953628084e-3],
-    [9.0, 26.0, 0.32308904703711e-2],
-    [10.0, 0.0, 0.80964802996215e-4],
-    [10.0, 1.0, -0.16557679795037e-3],
-    [11.0, 26.0, -0.44923899061815e-4],
+const REGION_3_COEFFS_II: [i32; 40] = [
+    0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 6, 6,
+    6, 7, 8, 9, 9, 10, 10, 11,
+];
+
+const REGION_3_COEFFS_JI: [i32; 40] = [
+    0, 0, 1, 2, 7, 10, 12, 23, 2, 6, 15, 17, 0, 2, 6, 7, 22, 26, 0, 2, 4, 16, 26, 0, 2, 4, 26, 1,
+    3, 26, 0, 2, 26, 2, 26, 2, 26, 0, 1, 26,
+];
+
+const REGION_3_COEFFS_NI: [f64; 40] = [
+    0.10658070028513e1,
+    -0.15732845290239e2,
+    0.20944396974307e2,
+    -0.76867707878716e1,
+    0.26185947787954e1,
+    -0.28080781148620e1,
+    0.12053369696517e1,
+    -0.84566812812502e-2,
+    -0.12654315477714e1,
+    -0.11524407806681e1,
+    0.88521043984318,
+    -0.64207765181607,
+    0.38493460186671,
+    -0.85214708824206,
+    0.48972281541877e1,
+    -0.30502617256965e1,
+    0.39420536879154e-1,
+    0.12558408424308,
+    -0.27999329698710,
+    0.13899799569460e1,
+    -0.20189915023570e1,
+    -0.82147637173963e-2,
+    -0.47596035734923,
+    0.43984074473500e-1,
+    -0.44476435428739,
+    0.90572070719733,
+    0.70522450087967,
+    0.10770512626332,
+    -0.32913623258954,
+    -0.50871062041158,
+    -0.22175400873096e-1,
+    0.94260751665092e-1,
+    0.16436278447961,
+    -0.13503372241348e-1,
+    -0.14834345352472e-1,
+    0.57922953628084e-3,
+    0.32308904703711e-2,
+    0.80964802996215e-4,
+    -0.16557679795037e-3,
+    -0.44923899061815e-4,
 ];
 
 // ================    Region 3 ===================
@@ -1773,62 +1783,62 @@ fn tau_3(t: f64) -> f64 {
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
 fn phi_3(rho: f64, t: f64) -> f64 {
-    let mut sum: f64 = 0.0;
     let tau: f64 = tau_3(t);
     let delta: f64 = delta_3(rho);
-    for coefficient in REGION_3_COEFFS.iter().skip(1) {
-        let ii: i32 = coefficient[0] as i32;
-        let ji: i32 = coefficient[1] as i32;
-        let ni: f64 = coefficient[2];
+    let mut sum: f64 = 0.0_f64;
+    for x in 1..REGION_3_COEFFS_II.len() {
+        let ii = REGION_3_COEFFS_II[x];
+        let ji = REGION_3_COEFFS_JI[x];
+        let ni = REGION_3_COEFFS_NI[x];
         sum += ni * delta.powi(ii) * tau.powi(ji);
     }
-    sum + REGION_3_COEFFS[0][2] * delta_3(rho).ln()
+    sum + REGION_3_COEFFS_NI[0] * delta_3(rho).ln()
 }
 
 /// Returns the region-3 phi_delta
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
 fn phi_delta_3(rho: f64, t: f64) -> f64 {
-    let mut sum: f64 = 0.0;
     let tau: f64 = tau_3(t);
     let delta: f64 = delta_3(rho);
-    for coefficient in REGION_3_COEFFS.iter().skip(1) {
-        let ii: i32 = coefficient[0] as i32;
-        let ji: i32 = coefficient[1] as i32;
-        let ni: f64 = coefficient[2];
-        sum += ni * delta.powi(ii - 1) * f64::from(ii) * tau.powi(ji);
+    let mut sum: f64 = 0.0_f64;
+    for x in 1..REGION_3_COEFFS_II.len() {
+        let ii = REGION_3_COEFFS_II[x];
+        let ji = REGION_3_COEFFS_JI[x];
+        let ni = REGION_3_COEFFS_NI[x];
+        sum += ni * delta.powi(ii - 1) * ii as f64 * tau.powi(ji);
     }
-    sum + REGION_3_COEFFS[0][2] / delta
+    sum + REGION_3_COEFFS_NI[0] / delta
 }
 
 /// Returns the region-3 phi_delta_delta
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
 fn phi_delta_delta_3(rho: f64, t: f64) -> f64 {
-    let mut sum: f64 = 0.0;
     let tau: f64 = tau_3(t);
     let delta: f64 = delta_3(rho);
-    for coefficient in REGION_3_COEFFS.iter().skip(1) {
-        let ii: i32 = coefficient[0] as i32;
-        let ji: i32 = coefficient[1] as i32;
-        let ni: f64 = coefficient[2];
-        sum += ni * delta.powi(ii - 2) * f64::from(ii) * f64::from(ii - 1) * tau.powi(ji);
+    let mut sum: f64 = 0.0_f64;
+    for x in 1..REGION_3_COEFFS_II.len() {
+        let ii = REGION_3_COEFFS_II[x];
+        let ji = REGION_3_COEFFS_JI[x];
+        let ni = REGION_3_COEFFS_NI[x];
+        sum += ni * delta.powi(ii - 2) * (ii * (ii - 1)) as f64 * tau.powi(ji);
     }
-    sum - REGION_3_COEFFS[0][2] / delta.powi(2)
+    sum - REGION_3_COEFFS_NI[0] / delta.powi(2)
 }
 
 /// Returns the region-3 phi_tau
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
 fn phi_tau_3(rho: f64, t: f64) -> f64 {
-    let mut sum: f64 = 0.0;
     let tau: f64 = tau_3(t);
     let delta: f64 = delta_3(rho);
-    for coefficient in REGION_3_COEFFS.iter().skip(1) {
-        let ii: i32 = coefficient[0] as i32;
-        let ji: i32 = coefficient[1] as i32;
-        let ni: f64 = coefficient[2];
-        sum += ni * delta.powi(ii) * f64::from(ji) * tau.powi(ji - 1);
+    let mut sum: f64 = 0.0_f64;
+    for x in 1..REGION_3_COEFFS_II.len() {
+        let ii = REGION_3_COEFFS_II[x];
+        let ji = REGION_3_COEFFS_JI[x];
+        let ni = REGION_3_COEFFS_NI[x];
+        sum += ni * delta.powi(ii) * ji as f64 * tau.powi(ji - 1);
     }
     sum
 }
@@ -1837,14 +1847,14 @@ fn phi_tau_3(rho: f64, t: f64) -> f64 {
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
 fn phi_tau_tau_3(rho: f64, t: f64) -> f64 {
-    let mut sum: f64 = 0.0;
     let tau: f64 = tau_3(t);
     let delta: f64 = delta_3(rho);
-    for coefficient in REGION_3_COEFFS.iter().skip(1) {
-        let ii: i32 = coefficient[0] as i32;
-        let ji: i32 = coefficient[1] as i32;
-        let ni: f64 = coefficient[2];
-        sum += ni * delta.powi(ii) * f64::from(ji) * f64::from(ji - 1) * tau.powi(ji - 2);
+    let mut sum: f64 = 0.0_f64;
+    for x in 1..REGION_3_COEFFS_II.len() {
+        let ii = REGION_3_COEFFS_II[x];
+        let ji = REGION_3_COEFFS_JI[x];
+        let ni = REGION_3_COEFFS_NI[x];
+        sum += ni * delta.powi(ii) * (ji * (ji - 1)) as f64 * tau.powi(ji - 2);
     }
     sum
 }
@@ -1853,14 +1863,14 @@ fn phi_tau_tau_3(rho: f64, t: f64) -> f64 {
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
 fn phi_delta_tau_3(rho: f64, t: f64) -> f64 {
-    let mut sum: f64 = 0.0;
     let tau: f64 = tau_3(t);
     let delta: f64 = delta_3(rho);
-    for coefficient in REGION_3_COEFFS.iter().skip(1) {
-        let ii: i32 = coefficient[0] as i32;
-        let ji: i32 = coefficient[1] as i32;
-        let ni: f64 = coefficient[2];
-        sum += ni * delta.powi(ii - 1) * f64::from(ii) * f64::from(ji) * tau.powi(ji - 1);
+    let mut sum: f64 = 0.0_f64;
+    for x in 1..REGION_3_COEFFS_II.len() {
+        let ii = REGION_3_COEFFS_II[x];
+        let ji = REGION_3_COEFFS_JI[x];
+        let ni = REGION_3_COEFFS_NI[x];
+        sum += ni * delta.powi(ii - 1) * (ii * ji) as f64 * tau.powi(ji - 1);
     }
     sum
 }

--- a/src/iapws97/region_3.rs
+++ b/src/iapws97/region_3.rs
@@ -123,12 +123,10 @@ fn subregion_a(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 30] = core::array::from_fn(|i| i + 1);
+    let x: [usize; 30] = core::array::from_fn(|i| i);
     let v: f64 = x
         .into_iter()
-        .map(|x| {
-            n[x - 1] * (((p * 1e-8) - 0.085).powi(i[x - 1]) * ((t / 760.0) - 0.817).powi(j[x - 1]))
-        })
+        .map(|x| n[x] * (((p * 1e-8) - 0.085).powi(i[x]) * ((t / 760.0) - 0.817).powi(j[x])))
         .sum();
     v * 0.0024
 }
@@ -180,12 +178,10 @@ fn subregion_b(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 32] = core::array::from_fn(|i| i + 1);
+    let x: [usize; 32] = core::array::from_fn(|i| i);
     let v: f64 = x
         .into_iter()
-        .map(|x| {
-            n[x - 1] * (((p * 1e-8) - 0.280).powi(i[x - 1]) * ((t / 860.0) - 0.779).powi(j[x - 1]))
-        })
+        .map(|x| n[x] * (((p * 1e-8) - 0.280).powi(i[x]) * ((t / 860.0) - 0.779).powi(j[x])))
         .sum();
     v * 0.0041
 }
@@ -240,13 +236,10 @@ fn subregion_c(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 35] = core::array::from_fn(|i| i + 1);
+    let x: [usize; 35] = core::array::from_fn(|i| i);
     let v: f64 = x
         .into_iter()
-        .map(|x| {
-            n[x - 1]
-                * (((p * 2.5e-8) - 0.259).powi(i[x - 1]) * ((t / 690.0) - 0.903).powi(j[x - 1]))
-        })
+        .map(|x| n[x] * (((p * 2.5e-8) - 0.259).powi(i[x]) * ((t / 690.0) - 0.903).powi(j[x])))
         .sum();
     v * 0.0022
 }
@@ -304,13 +297,10 @@ fn subregion_d(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 38] = core::array::from_fn(|i| i + 1);
+    let x: [usize; 38] = core::array::from_fn(|i| i);
     let v: f64 = x
         .into_iter()
-        .map(|x| {
-            n[x - 1]
-                * (((p * 2.5e-8) - 0.559).powi(i[x - 1]) * ((t / 690.0) - 0.939).powi(j[x - 1]))
-        })
+        .map(|x| n[x] * (((p * 2.5e-8) - 0.559).powi(i[x]) * ((t / 690.0) - 0.939).powi(j[x])))
         .sum();
     v.powi(4) * 0.0029
 }
@@ -358,13 +348,10 @@ fn subregion_e(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 29] = core::array::from_fn(|i| i + 1);
+    let x: [usize; 29] = core::array::from_fn(|i| i);
     let v: f64 = x
         .into_iter()
-        .map(|x| {
-            n[x - 1]
-                * (((p * 2.5e-8) - 0.587).powi(i[x - 1]) * ((t / 710.0) - 0.918).powi(j[x - 1]))
-        })
+        .map(|x| n[x] * (((p * 2.5e-8) - 0.587).powi(i[x]) * ((t / 710.0) - 0.918).powi(j[x])))
         .sum();
     v * 0.0032
 }
@@ -426,13 +413,12 @@ fn subregion_f(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 42] = core::array::from_fn(|i| i + 1);
+    let x: [usize; 42] = core::array::from_fn(|i| i);
     let v: f64 = x
         .into_iter()
         .map(|x| {
-            n[x - 1]
-                * ((((p * 002.5e-8) - 0.587).powf(0.5)).powi(i[x - 1])
-                    * ((t / 730.0) - 0.891).powi(j[x - 1]))
+            n[x] * ((((p * 002.5e-8) - 0.587).powf(0.5)).powi(i[x])
+                * ((t / 730.0) - 0.891).powi(j[x]))
         })
         .sum();
     v.powi(4) * 0.0064
@@ -491,13 +477,10 @@ fn subregion_g(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 38] = core::array::from_fn(|i| i + 1);
+    let x: [usize; 38] = core::array::from_fn(|i| i);
     let v: f64 = x
         .into_iter()
-        .map(|x| {
-            n[x - 1]
-                * (((p * 4.0e-8) - 0.872).powi(i[x - 1]) * ((t / 660.0) - 0.971).powi(j[x - 1]))
-        })
+        .map(|x| n[x] * (((p * 4.0e-8) - 0.872).powi(i[x]) * ((t / 660.0) - 0.971).powi(j[x])))
         .sum();
     v.powi(4) * 0.0027
 }
@@ -545,13 +528,10 @@ fn subregion_h(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 29] = core::array::from_fn(|i| i + 1);
+    let x: [usize; 29] = core::array::from_fn(|i| i);
     let v: f64 = x
         .into_iter()
-        .map(|x| {
-            n[x - 1]
-                * (((p * 4.0e-8) - 0.898).powi(i[x - 1]) * ((t / 660.0) - 0.983).powi(j[x - 1]))
-        })
+        .map(|x| n[x] * (((p * 4.0e-8) - 0.898).powi(i[x]) * ((t / 660.0) - 0.983).powi(j[x])))
         .sum();
     v.powi(4) * 0.0032
 }
@@ -613,13 +593,12 @@ fn subregion_i(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 42] = core::array::from_fn(|i| i + 1);
+    let x: [usize; 42] = core::array::from_fn(|i| i);
     let v: f64 = x
         .into_iter()
         .map(|x| {
-            n[x - 1]
-                * ((((p * 4.0e-8) - 0.910).powf(0.5)).powi(i[x - 1])
-                    * ((t / 660.0) - 0.984).powi(j[x - 1]))
+            n[x] * ((((p * 4.0e-8) - 0.910).powf(0.5)).powi(i[x])
+                * ((t / 660.0) - 0.984).powi(j[x]))
         })
         .sum();
     v.powi(4) * 0.0041
@@ -669,13 +648,12 @@ fn subregion_j(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 29] = core::array::from_fn(|i| i + 1);
+    let x: [usize; 29] = core::array::from_fn(|i| i);
     let v: f64 = x
         .into_iter()
         .map(|x| {
-            n[x - 1]
-                * ((((p * 4.0e-8) - 0.875).powf(0.5)).powi(i[x - 1])
-                    * ((t / 670.0) - 0.964).powi(j[x - 1]))
+            n[x] * ((((p * 4.0e-8) - 0.875).powf(0.5)).powi(i[x])
+                * ((t / 670.0) - 0.964).powi(j[x]))
         })
         .sum();
     v.powi(4) * 0.0054
@@ -730,13 +708,10 @@ fn subregion_k(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 34] = core::array::from_fn(|i| i + 1);
+    let x: [usize; 34] = core::array::from_fn(|i| i);
     let v: f64 = x
         .into_iter()
-        .map(|x| {
-            n[x - 1]
-                * (((p * 4.0e-8) - 0.802).powi(i[x - 1]) * ((t / 680.0) - 0.935).powi(j[x - 1]))
-        })
+        .map(|x| n[x] * (((p * 4.0e-8) - 0.802).powi(i[x]) * ((t / 680.0) - 0.935).powi(j[x])))
         .sum();
     v * 0.0077
 }
@@ -799,13 +774,10 @@ fn subregion_l(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 43] = core::array::from_fn(|i| i + 1);
+    let x: [usize; 43] = core::array::from_fn(|i| i);
     let v: f64 = x
         .into_iter()
-        .map(|x| {
-            n[x - 1]
-                * (((p / 24.0e6) - 0.908).powi(i[x - 1]) * ((t / 650.0) - 0.989).powi(j[x - 1]))
-        })
+        .map(|x| n[x] * (((p / 24.0e6) - 0.908).powi(i[x]) * ((t / 650.0) - 0.989).powi(j[x])))
         .sum();
     v.powi(4) * 0.0026
 }
@@ -865,13 +837,11 @@ fn subregion_m(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 40] = core::array::from_fn(|i| i + 1);
+    let x: [usize; 40] = core::array::from_fn(|i| i);
     let v: f64 = x
         .into_iter()
         .map(|x| {
-            n[x - 1]
-                * (((p / 23.0e6) - 1.0).powi(i[x - 1])
-                    * (((t / 650.0) - 0.997).powf(0.25)).powi(j[x - 1]))
+            n[x] * (((p / 23.0e6) - 1.0).powi(i[x]) * (((t / 650.0) - 0.997).powf(0.25)).powi(j[x]))
         })
         .sum();
     v * 0.0028
@@ -931,13 +901,10 @@ fn subregion_n(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 39] = core::array::from_fn(|i| i + 1);
+    let x: [usize; 39] = core::array::from_fn(|i| i);
     let v: f64 = x
         .into_iter()
-        .map(|x| {
-            n[x - 1]
-                * (((p / 23.0e6) - 0.976).powi(i[x - 1]) * ((t / 650.0) - 0.997).powi(j[x - 1]))
-        })
+        .map(|x| n[x] * (((p / 23.0e6) - 0.976).powi(i[x]) * ((t / 650.0) - 0.997).powi(j[x])))
         .sum();
     v.exp() * 0.0031
 }
@@ -980,13 +947,12 @@ fn subregion_o(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 24] = core::array::from_fn(|i| i + 1);
+    let x: [usize; 24] = core::array::from_fn(|i| i);
     let v: f64 = x
         .into_iter()
         .map(|x| {
-            n[x - 1]
-                * ((((p / 23.0e6) - 0.974).powf(0.5)).powi(i[x - 1])
-                    * ((t / 650.0) - 0.996).powi(j[x - 1]))
+            n[x] * ((((p / 23.0e6) - 0.974).powf(0.5)).powi(i[x])
+                * ((t / 650.0) - 0.996).powi(j[x]))
         })
         .sum();
     v * 0.0034
@@ -1034,13 +1000,12 @@ fn subregion_p(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 27] = core::array::from_fn(|i| i + 1);
+    let x: [usize; 27] = core::array::from_fn(|i| i);
     let v: f64 = x
         .into_iter()
         .map(|x| {
-            n[x - 1]
-                * ((((p / 23.0e6) - 0.972).powf(0.5)).powi(i[x - 1])
-                    * ((t / 650.0) - 0.997).powi(j[x - 1]))
+            n[x] * ((((p / 23.0e6) - 0.972).powf(0.5)).powi(i[x])
+                * ((t / 650.0) - 0.997).powi(j[x]))
         })
         .sum();
     v * 0.0041
@@ -1084,12 +1049,10 @@ fn subregion_q(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 24] = core::array::from_fn(|i| i + 1);
+    let x: [usize; 24] = core::array::from_fn(|i| i);
     let v: f64 = x
         .into_iter()
-        .map(|x| {
-            n[x - 1] * (((p / 23e6) - 0.848).powi(i[x - 1]) * ((t / 650.0) - 0.983).powi(j[x - 1]))
-        })
+        .map(|x| n[x] * (((p / 23e6) - 0.848).powi(i[x]) * ((t / 650.0) - 0.983).powi(j[x])))
         .sum();
     v.powi(4) * 0.0022
 }
@@ -1136,12 +1099,10 @@ fn subregion_r(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 27] = core::array::from_fn(|i| i + 1);
+    let x: [usize; 27] = core::array::from_fn(|i| i);
     let v: f64 = x
         .into_iter()
-        .map(|x| {
-            n[x - 1] * (((p / 23e6) - 0.874).powi(i[x - 1]) * ((t / 650.0) - 0.982).powi(j[x - 1]))
-        })
+        .map(|x| n[x] * (((p / 23e6) - 0.874).powi(i[x]) * ((t / 650.0) - 0.982).powi(j[x])))
         .sum();
     v * 0.0054
 }
@@ -1190,12 +1151,10 @@ fn subregion_s(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 29] = core::array::from_fn(|i| i + 1);
+    let x: [usize; 29] = core::array::from_fn(|i| i);
     let v: f64 = x
         .into_iter()
-        .map(|x| {
-            n[x - 1] * (((p / 21e6) - 0.886).powi(i[x - 1]) * ((t / 640.0) - 0.990).powi(j[x - 1]))
-        })
+        .map(|x| n[x] * (((p / 21e6) - 0.886).powi(i[x]) * ((t / 640.0) - 0.990).powi(j[x])))
         .sum();
     v.powi(4) * 0.0022
 }
@@ -1248,12 +1207,10 @@ fn subregion_t(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 33] = core::array::from_fn(|i| i + 1);
+    let x: [usize; 33] = core::array::from_fn(|i| i);
     let v: f64 = x
         .into_iter()
-        .map(|x| {
-            n[x - 1] * (((p / 20e6) - 0.803).powi(i[x - 1]) * ((t / 650.0) - 1.020).powi(j[x - 1]))
-        })
+        .map(|x| n[x] * (((p / 20e6) - 0.803).powi(i[x]) * ((t / 650.0) - 1.020).powi(j[x])))
         .sum();
     v * 0.0088
 }
@@ -1311,12 +1268,10 @@ fn subregion_u(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 38] = core::array::from_fn(|i| i + 1);
+    let x: [usize; 38] = core::array::from_fn(|i| i);
     let v: f64 = x
         .into_iter()
-        .map(|x| {
-            n[x - 1] * (((p / 23e6) - 0.902).powi(i[x - 1]) * ((t / 650.0) - 0.988).powi(j[x - 1]))
-        })
+        .map(|x| n[x] * (((p / 23e6) - 0.902).powi(i[x]) * ((t / 650.0) - 0.988).powi(j[x])))
         .sum();
     v * 0.0026
 }
@@ -1375,12 +1330,10 @@ fn subregion_v(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 39] = core::array::from_fn(|i| i + 1);
+    let x: [usize; 39] = core::array::from_fn(|i| i);
     let v: f64 = x
         .into_iter()
-        .map(|x| {
-            n[x - 1] * (((p / 23e6) - 0.960).powi(i[x - 1]) * ((t / 650.0) - 0.995).powi(j[x - 1]))
-        })
+        .map(|x| n[x] * (((p / 23e6) - 0.960).powi(i[x]) * ((t / 650.0) - 0.995).powi(j[x])))
         .sum();
     v * 0.0031
 }
@@ -1435,12 +1388,10 @@ fn subregion_w(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 35] = core::array::from_fn(|i| i + 1);
+    let x: [usize; 35] = core::array::from_fn(|i| i);
     let v: f64 = x
         .into_iter()
-        .map(|x| {
-            n[x - 1] * (((p / 23e6) - 0.959).powi(i[x - 1]) * ((t / 650.0) - 0.995).powi(j[x - 1]))
-        })
+        .map(|x| n[x] * (((p / 23e6) - 0.959).powi(i[x]) * ((t / 650.0) - 0.995).powi(j[x])))
         .sum();
     v.powi(4) * 0.0039
 }
@@ -1496,12 +1447,10 @@ fn subregion_x(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 36] = core::array::from_fn(|i| i + 1);
+    let x: [usize; 36] = core::array::from_fn(|i| i);
     let v: f64 = x
         .into_iter()
-        .map(|x| {
-            n[x - 1] * (((p / 23e6) - 0.910).powi(i[x - 1]) * ((t / 650.0) - 0.988).powi(j[x - 1]))
-        })
+        .map(|x| n[x] * (((p / 23e6) - 0.910).powi(i[x]) * ((t / 650.0) - 0.988).powi(j[x])))
         .sum();
     v * 0.0049
 }
@@ -1537,12 +1486,10 @@ fn subregion_y(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 20] = core::array::from_fn(|i| i + 1);
+    let x: [usize; 20] = core::array::from_fn(|i| i);
     let v: f64 = x
         .into_iter()
-        .map(|x| {
-            n[x - 1] * (((p / 22e6) - 0.996).powi(i[x - 1]) * ((t / 650.0) - 0.994).powi(j[x - 1]))
-        })
+        .map(|x| n[x] * (((p / 22e6) - 0.996).powi(i[x]) * ((t / 650.0) - 0.994).powi(j[x])))
         .sum();
     v.powi(4) * 0.0031
 }
@@ -1583,12 +1530,10 @@ fn subregion_z(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 23] = core::array::from_fn(|i| i + 1);
+    let x: [usize; 23] = core::array::from_fn(|i| i);
     let v: f64 = x
         .into_iter()
-        .map(|x| {
-            n[x - 1] * (((p / 22e6) - 0.993).powi(i[x - 1]) * ((t / 650.0) - 0.994).powi(j[x - 1]))
-        })
+        .map(|x| n[x] * (((p / 22e6) - 0.993).powi(i[x]) * ((t / 650.0) - 0.994).powi(j[x])))
         .sum();
     v.powi(4) * 0.0038
 }

--- a/src/iapws97/region_3.rs
+++ b/src/iapws97/region_3.rs
@@ -1,4 +1,5 @@
 use crate::iapws97::{constants, psat97};
+#[cfg(feature = "nightly")]
 use std::simd::prelude::*;
 
 use super::tsat97;
@@ -134,7 +135,8 @@ fn subregion_a(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (p_base, t_base): ([f64; 30], [f64; 30]) = (
             std::array::from_fn(|x| ((p * 1e-8) - 0.085).powi(i[x])),
             std::array::from_fn(|x| ((t / 760.0) - 0.817).powi(j[x])),
@@ -145,7 +147,9 @@ fn subregion_a(t: f64, p: f64) -> f64 {
         let p_base = Simd::<f64, 32>::load_or_default(&p_base);
 
         0.0024 * (n * p_base * t_base).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let x: [usize; 30] = core::array::from_fn(|i| i);
         let v: f64 = x
             .into_iter()
@@ -202,7 +206,8 @@ fn subregion_b(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (p_base, t_base): ([f64; 32], [f64; 32]) = (
             std::array::from_fn(|x| ((p * 1e-8) - 0.280).powi(i[x])),
             std::array::from_fn(|x| ((t / 860.0) - 0.779).powi(j[x])),
@@ -213,7 +218,9 @@ fn subregion_b(t: f64, p: f64) -> f64 {
         let p_base = Simd::<f64, 32>::load_or_default(&p_base);
 
         0.0041 * (n * p_base * t_base).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let x: [usize; 32] = core::array::from_fn(|i| i);
         let v: f64 = x
             .into_iter()
@@ -273,7 +280,8 @@ fn subregion_c(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (p_base, t_base): ([f64; 35], [f64; 35]) = (
             std::array::from_fn(|x| ((p * 2.5e-8) - 0.259).powi(i[x])),
             std::array::from_fn(|x| ((t / 690.0) - 0.903).powi(j[x])),
@@ -284,7 +292,9 @@ fn subregion_c(t: f64, p: f64) -> f64 {
         let p_base = Simd::<f64, 64>::load_or_default(&p_base);
 
         0.0022 * (n * p_base * t_base).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let x: [usize; 35] = core::array::from_fn(|i| i);
         let v: f64 = x
             .into_iter()
@@ -347,7 +357,8 @@ fn subregion_d(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (p_base, t_base): ([f64; 38], [f64; 38]) = (
             std::array::from_fn(|x| ((p * 2.5e-8) - 0.559).powi(i[x])),
             std::array::from_fn(|x| ((t / 690.0) - 0.939).powi(j[x])),
@@ -358,7 +369,9 @@ fn subregion_d(t: f64, p: f64) -> f64 {
         let p_base = Simd::<f64, 64>::load_or_default(&p_base);
 
         0.0029 * ((n * p_base * t_base).reduce_sum()).powi(4)
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let x: [usize; 38] = core::array::from_fn(|i| i);
         let v: f64 = x
             .into_iter()
@@ -411,7 +424,8 @@ fn subregion_e(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (p_base, t_base): ([f64; 29], [f64; 29]) = (
             std::array::from_fn(|x| ((p * 2.5e-8) - 0.587).powi(i[x])),
             std::array::from_fn(|x| ((t / 710.0) - 0.918).powi(j[x])),
@@ -422,7 +436,9 @@ fn subregion_e(t: f64, p: f64) -> f64 {
         let p_base = Simd::<f64, 32>::load_or_default(&p_base);
 
         0.0032 * (n * p_base * t_base).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let x: [usize; 29] = core::array::from_fn(|i| i);
         let v: f64 = x
             .into_iter()
@@ -489,7 +505,8 @@ fn subregion_f(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (p_base, t_base): ([f64; 42], [f64; 42]) = (
             std::array::from_fn(|x| (((p * 2.5e-8) - 0.587).powf(0.5)).powi(i[x])),
             std::array::from_fn(|x| ((t / 730.0) - 0.891).powi(j[x])),
@@ -500,7 +517,9 @@ fn subregion_f(t: f64, p: f64) -> f64 {
         let p_base = Simd::<f64, 64>::load_or_default(&p_base);
 
         0.0064 * ((n * p_base * t_base).reduce_sum()).powi(4)
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let x: [usize; 42] = core::array::from_fn(|i| i);
         let v: f64 = x
             .into_iter()
@@ -566,7 +585,8 @@ fn subregion_g(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (p_base, t_base): ([f64; 38], [f64; 38]) = (
             std::array::from_fn(|x| ((p * 4.0e-8) - 0.872).powi(i[x])),
             std::array::from_fn(|x| ((t / 660.0) - 0.971).powi(j[x])),
@@ -577,7 +597,9 @@ fn subregion_g(t: f64, p: f64) -> f64 {
         let p_base = Simd::<f64, 64>::load_or_default(&p_base);
 
         0.0027 * ((n * p_base * t_base).reduce_sum()).powi(4)
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let x: [usize; 38] = core::array::from_fn(|i| i);
         let v: f64 = x
             .into_iter()
@@ -630,7 +652,8 @@ fn subregion_h(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (p_base, t_base): ([f64; 29], [f64; 29]) = (
             std::array::from_fn(|x| ((p * 4.0e-8) - 0.898).powi(i[x])),
             std::array::from_fn(|x| ((t / 660.0) - 0.983).powi(j[x])),
@@ -641,7 +664,9 @@ fn subregion_h(t: f64, p: f64) -> f64 {
         let p_base = Simd::<f64, 32>::load_or_default(&p_base);
 
         0.0032 * ((n * p_base * t_base).reduce_sum()).powi(4)
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let x: [usize; 29] = core::array::from_fn(|i| i);
         let v: f64 = x
             .into_iter()
@@ -708,7 +733,8 @@ fn subregion_i(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (p_base, t_base): ([f64; 42], [f64; 42]) = (
             std::array::from_fn(|x| (((p * 4.0e-8) - 0.910).powf(0.5)).powi(i[x])),
             std::array::from_fn(|x| ((t / 660.0) - 0.984).powi(j[x])),
@@ -719,7 +745,9 @@ fn subregion_i(t: f64, p: f64) -> f64 {
         let p_base = Simd::<f64, 64>::load_or_default(&p_base);
 
         0.0041 * ((n * p_base * t_base).reduce_sum()).powi(4)
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let x: [usize; 42] = core::array::from_fn(|i| i);
         let v: f64 = x
             .into_iter()
@@ -776,7 +804,8 @@ fn subregion_j(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (p_base, t_base): ([f64; 29], [f64; 29]) = (
             std::array::from_fn(|x| (((p * 4.0e-8) - 0.875).powf(0.5)).powi(i[x])),
             std::array::from_fn(|x| ((t / 670.0) - 0.964).powi(j[x])),
@@ -787,7 +816,9 @@ fn subregion_j(t: f64, p: f64) -> f64 {
         let p_base = Simd::<f64, 32>::load_or_default(&p_base);
 
         0.0054 * ((n * p_base * t_base).reduce_sum()).powi(4)
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let x: [usize; 29] = core::array::from_fn(|i| i);
         let v: f64 = x
             .into_iter()
@@ -849,7 +880,8 @@ fn subregion_k(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (p_base, t_base): ([f64; 34], [f64; 34]) = (
             std::array::from_fn(|x| ((p * 4.0e-8) - 0.802).powi(i[x])),
             std::array::from_fn(|x| ((t / 680.0) - 0.935).powi(j[x])),
@@ -860,7 +892,9 @@ fn subregion_k(t: f64, p: f64) -> f64 {
         let p_base = Simd::<f64, 64>::load_or_default(&p_base);
 
         0.0077 * (n * p_base * t_base).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let x: [usize; 34] = core::array::from_fn(|i| i);
         let v: f64 = x
             .into_iter()
@@ -928,7 +962,8 @@ fn subregion_l(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (p_base, t_base): ([f64; 43], [f64; 43]) = (
             std::array::from_fn(|x| ((p / 24.0e6) - 0.908).powi(i[x])),
             std::array::from_fn(|x| ((t / 650.0) - 0.989).powi(j[x])),
@@ -939,7 +974,9 @@ fn subregion_l(t: f64, p: f64) -> f64 {
         let p_base = Simd::<f64, 64>::load_or_default(&p_base);
 
         0.0026 * ((n * p_base * t_base).reduce_sum()).powi(4)
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let x: [usize; 43] = core::array::from_fn(|i| i);
         let v: f64 = x
             .into_iter()
@@ -1004,7 +1041,8 @@ fn subregion_m(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (p_base, t_base): ([f64; 40], [f64; 40]) = (
             std::array::from_fn(|x| ((p / 23.0e6) - 1.0).powi(i[x])),
             std::array::from_fn(|x| (((t / 650.0) - 0.997).powf(0.25)).powi(j[x])),
@@ -1015,7 +1053,9 @@ fn subregion_m(t: f64, p: f64) -> f64 {
         let p_base = Simd::<f64, 64>::load_or_default(&p_base);
 
         0.0028 * (n * p_base * t_base).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let x: [usize; 40] = core::array::from_fn(|i| i);
         let v: f64 = x
             .into_iter()
@@ -1082,7 +1122,8 @@ fn subregion_n(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (p_base, t_base): ([f64; 39], [f64; 39]) = (
             std::array::from_fn(|x| ((p / 23.0e6) - 0.976).powi(i[x])),
             std::array::from_fn(|x| ((t / 650.0) - 0.997).powi(j[x])),
@@ -1093,7 +1134,9 @@ fn subregion_n(t: f64, p: f64) -> f64 {
         let p_base = Simd::<f64, 64>::load_or_default(&p_base);
 
         0.0031 * ((n * p_base * t_base).reduce_sum()).exp()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let x: [usize; 39] = core::array::from_fn(|i| i);
         let v: f64 = x
             .into_iter()
@@ -1141,7 +1184,8 @@ fn subregion_o(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (p_base, t_base): ([f64; 24], [f64; 24]) = (
             std::array::from_fn(|x| (((p / 23.0e6) - 0.974).powf(0.5)).powi(i[x])),
             std::array::from_fn(|x| ((t / 650.0) - 0.996).powi(j[x])),
@@ -1152,7 +1196,9 @@ fn subregion_o(t: f64, p: f64) -> f64 {
         let p_base = Simd::<f64, 32>::load_or_default(&p_base);
 
         0.0034 * (n * p_base * t_base).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let x: [usize; 24] = core::array::from_fn(|i| i);
         let v: f64 = x
             .into_iter()
@@ -1207,7 +1253,8 @@ fn subregion_p(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (p_base, t_base): ([f64; 27], [f64; 27]) = (
             std::array::from_fn(|x| (((p / 23.0e6) - 0.972).powf(0.5)).powi(i[x])),
             std::array::from_fn(|x| ((t / 650.0) - 0.997).powi(j[x])),
@@ -1218,7 +1265,9 @@ fn subregion_p(t: f64, p: f64) -> f64 {
         let p_base = Simd::<f64, 32>::load_or_default(&p_base);
 
         0.0041 * (n * p_base * t_base).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let x: [usize; 27] = core::array::from_fn(|i| i);
         let v: f64 = x
             .into_iter()
@@ -1269,7 +1318,8 @@ fn subregion_q(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (p_base, t_base): ([f64; 24], [f64; 24]) = (
             std::array::from_fn(|x| ((p / 23e6) - 0.848).powi(i[x])),
             std::array::from_fn(|x| ((t / 650.0) - 0.983).powi(j[x])),
@@ -1280,7 +1330,9 @@ fn subregion_q(t: f64, p: f64) -> f64 {
         let p_base = Simd::<f64, 32>::load_or_default(&p_base);
 
         0.0022 * ((n * p_base * t_base).reduce_sum()).powi(4)
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let x: [usize; 24] = core::array::from_fn(|i| i);
         let v: f64 = x
             .into_iter()
@@ -1332,7 +1384,8 @@ fn subregion_r(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (p_base, t_base): ([f64; 27], [f64; 27]) = (
             std::array::from_fn(|x| ((p / 23e6) - 0.874).powi(i[x])),
             std::array::from_fn(|x| ((t / 650.0) - 0.982).powi(j[x])),
@@ -1343,7 +1396,9 @@ fn subregion_r(t: f64, p: f64) -> f64 {
         let p_base = Simd::<f64, 32>::load_or_default(&p_base);
 
         0.0054 * (n * p_base * t_base).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let x: [usize; 27] = core::array::from_fn(|i| i);
         let v: f64 = x
             .into_iter()
@@ -1397,7 +1452,8 @@ fn subregion_s(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (p_base, t_base): ([f64; 29], [f64; 29]) = (
             std::array::from_fn(|x| ((p / 21e6) - 0.886).powi(i[x])),
             std::array::from_fn(|x| ((t / 640.0) - 0.990).powi(j[x])),
@@ -1408,7 +1464,9 @@ fn subregion_s(t: f64, p: f64) -> f64 {
         let p_base = Simd::<f64, 32>::load_or_default(&p_base);
 
         0.0022 * ((n * p_base * t_base).reduce_sum()).powi(4)
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let x: [usize; 29] = core::array::from_fn(|i| i);
         let v: f64 = x
             .into_iter()
@@ -1466,7 +1524,8 @@ fn subregion_t(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (p_base, t_base): ([f64; 33], [f64; 33]) = (
             std::array::from_fn(|x| ((p / 20e6) - 0.803).powi(i[x])),
             std::array::from_fn(|x| ((t / 650.0) - 1.020).powi(j[x])),
@@ -1477,7 +1536,9 @@ fn subregion_t(t: f64, p: f64) -> f64 {
         let p_base = Simd::<f64, 64>::load_or_default(&p_base);
 
         0.0088 * (n * p_base * t_base).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let x: [usize; 33] = core::array::from_fn(|i| i);
         let v: f64 = x
             .into_iter()
@@ -1540,7 +1601,8 @@ fn subregion_u(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (p_base, t_base): ([f64; 38], [f64; 38]) = (
             std::array::from_fn(|x| ((p / 23e6) - 0.902).powi(i[x])),
             std::array::from_fn(|x| ((t / 650.0) - 0.988).powi(j[x])),
@@ -1551,7 +1613,9 @@ fn subregion_u(t: f64, p: f64) -> f64 {
         let p_base = Simd::<f64, 64>::load_or_default(&p_base);
 
         0.0026 * (n * p_base * t_base).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let x: [usize; 38] = core::array::from_fn(|i| i);
         let v: f64 = x
             .into_iter()
@@ -1615,7 +1679,8 @@ fn subregion_v(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (p_base, t_base): ([f64; 39], [f64; 39]) = (
             std::array::from_fn(|x| ((p / 23e6) - 0.960).powi(i[x])),
             std::array::from_fn(|x| ((t / 650.0) - 0.995).powi(j[x])),
@@ -1626,7 +1691,9 @@ fn subregion_v(t: f64, p: f64) -> f64 {
         let p_base = Simd::<f64, 64>::load_or_default(&p_base);
 
         0.0031 * (n * p_base * t_base).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let x: [usize; 39] = core::array::from_fn(|i| i);
         let v: f64 = x
             .into_iter()
@@ -1686,7 +1753,8 @@ fn subregion_w(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (p_base, t_base): ([f64; 35], [f64; 35]) = (
             std::array::from_fn(|x| ((p / 23e6) - 0.959).powi(i[x])),
             std::array::from_fn(|x| ((t / 650.0) - 0.995).powi(j[x])),
@@ -1697,7 +1765,9 @@ fn subregion_w(t: f64, p: f64) -> f64 {
         let p_base = Simd::<f64, 64>::load_or_default(&p_base);
 
         0.0039 * ((n * p_base * t_base).reduce_sum()).powi(4)
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let x: [usize; 35] = core::array::from_fn(|i| i);
         let v: f64 = x
             .into_iter()
@@ -1758,7 +1828,8 @@ fn subregion_x(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (p_base, t_base): ([f64; 36], [f64; 36]) = (
             std::array::from_fn(|x| ((p / 23e6) - 0.910).powi(i[x])),
             std::array::from_fn(|x| ((t / 650.0) - 0.988).powi(j[x])),
@@ -1769,7 +1840,9 @@ fn subregion_x(t: f64, p: f64) -> f64 {
         let p_base = Simd::<f64, 64>::load_or_default(&p_base);
 
         0.0049 * (n * p_base * t_base).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let x: [usize; 36] = core::array::from_fn(|i| i);
         let v: f64 = x
             .into_iter()
@@ -1810,7 +1883,8 @@ fn subregion_y(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (p_base, t_base): ([f64; 20], [f64; 20]) = (
             std::array::from_fn(|x| ((p / 22e6) - 0.996).powi(i[x])),
             std::array::from_fn(|x| ((t / 650.0) - 0.994).powi(j[x])),
@@ -1821,7 +1895,9 @@ fn subregion_y(t: f64, p: f64) -> f64 {
         let p_base = Simd::<f64, 32>::load_or_default(&p_base);
 
         0.0031 * ((n * p_base * t_base).reduce_sum()).powi(4)
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let x: [usize; 20] = core::array::from_fn(|i| i);
         let v: f64 = x
             .into_iter()
@@ -1867,7 +1943,8 @@ fn subregion_z(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (p_base, t_base): ([f64; 23], [f64; 23]) = (
             std::array::from_fn(|x| ((p / 22e6) - 0.993).powi(i[x])),
             std::array::from_fn(|x| ((t / 650.0) - 0.994).powi(j[x])),
@@ -1878,7 +1955,9 @@ fn subregion_z(t: f64, p: f64) -> f64 {
         let p_base = Simd::<f64, 32>::load_or_default(&p_base);
 
         0.0038 * ((n * p_base * t_base).reduce_sum()).powi(4)
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let x: [usize; 23] = core::array::from_fn(|i| i);
         let v: f64 = x
             .into_iter()
@@ -1892,380 +1971,484 @@ fn subregion_z(t: f64, p: f64) -> f64 {
 // to the state of water given t and p
 fn subregion(t: f64, p: f64) -> Region3 {
     // Create coefficient Arrays
-    let (t_ab, t_cd, t_ef, t_gh, t_ij, t_jk, t_mn, t_op, t_qu, t_rx, t_uv, t_wx) =
-        if cfg!(feature = "nightly") {
-            let coefficients_ab: Simd<f64, 8> = [
-                0.154793642129415e4,
-                -0.187661219490113e3,
-                0.213144632222113e2,
-                -0.191887498864292e4,
-                0.918419702359447e3,
-                0.0,
-                0.0,
-                0.0,
-            ]
-            .into();
+    #[cfg(feature = "nightly")]
+    {
+        let coefficients_ab: Simd<f64, 8> = [
+            0.154793642129415e4,
+            -0.187661219490113e3,
+            0.213144632222113e2,
+            -0.191887498864292e4,
+            0.918419702359447e3,
+            0.0,
+            0.0,
+            0.0,
+        ]
+        .into();
 
-            let coefficients_cd: Simd<f64, 8> = [
-                0.585276966696349e3,
-                0.278233532206915e1,
-                -0.127283549295878e-1,
-                0.159090746562729e-3,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-            ]
-            .into();
+        let coefficients_cd: Simd<f64, 8> = [
+            0.585276966696349e3,
+            0.278233532206915e1,
+            -0.127283549295878e-1,
+            0.159090746562729e-3,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+        ]
+        .into();
 
-            let coefficients_gh: Simd<f64, 8> = [
-                -0.249284240900418e5,
-                0.428143584791546e4,
-                -0.269029173140130e3,
-                0.751608051114157e1,
-                -0.787105249910383e-1,
-                0.0,
-                0.0,
-                0.0,
-            ]
-            .into();
+        let coefficients_gh: Simd<f64, 8> = [
+            -0.249284240900418e5,
+            0.428143584791546e4,
+            -0.269029173140130e3,
+            0.751608051114157e1,
+            -0.787105249910383e-1,
+            0.0,
+            0.0,
+            0.0,
+        ]
+        .into();
 
-            let coefficients_ij: Simd<f64, 8> = [
-                0.584814781649163e3,
-                -0.616179320924617,
-                0.260763050899562,
-                -0.587071076864459e-2,
-                0.515308185433082e-4,
-                0.0,
-                0.0,
-                0.0,
-            ]
-            .into();
+        let coefficients_ij: Simd<f64, 8> = [
+            0.584814781649163e3,
+            -0.616179320924617,
+            0.260763050899562,
+            -0.587071076864459e-2,
+            0.515308185433082e-4,
+            0.0,
+            0.0,
+            0.0,
+        ]
+        .into();
 
-            let coefficients_jk: Simd<f64, 8> = [
-                0.617229772068439e3,
-                -0.770600270141675e1,
-                0.697072596851896,
-                -0.157391839848015e-1,
-                0.137897492684194e-3,
-                0.0,
-                0.0,
-                0.0,
-            ]
-            .into();
+        let coefficients_jk: Simd<f64, 8> = [
+            0.617229772068439e3,
+            -0.770600270141675e1,
+            0.697072596851896,
+            -0.157391839848015e-1,
+            0.137897492684194e-3,
+            0.0,
+            0.0,
+            0.0,
+        ]
+        .into();
 
-            let coefficients_mn: Simd<f64, 8> = [
-                0.535339483742384e3,
-                0.761978122720128e1,
-                -0.158365725441648,
-                0.192871054508108e-2,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-            ]
-            .into();
+        let coefficients_mn: Simd<f64, 8> = [
+            0.535339483742384e3,
+            0.761978122720128e1,
+            -0.158365725441648,
+            0.192871054508108e-2,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+        ]
+        .into();
 
-            let coefficients_op: Simd<f64, 8> = [
-                0.969461372400213e3,
-                -0.332500170441278e3,
-                0.642859598466067e2,
-                0.773845935768222e3,
-                -0.152313732937084e4,
-                0.0,
-                0.0,
-                0.0,
-            ]
-            .into();
+        let coefficients_op: Simd<f64, 8> = [
+            0.969461372400213e3,
+            -0.332500170441278e3,
+            0.642859598466067e2,
+            0.773845935768222e3,
+            -0.152313732937084e4,
+            0.0,
+            0.0,
+            0.0,
+        ]
+        .into();
 
-            let coefficients_qu: Simd<f64, 8> = [
-                0.565603648239126e3,
-                0.529062258221222e1,
-                -0.102020639611016,
-                0.122240301070145e-2,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-            ]
-            .into();
+        let coefficients_qu: Simd<f64, 8> = [
+            0.565603648239126e3,
+            0.529062258221222e1,
+            -0.102020639611016,
+            0.122240301070145e-2,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+        ]
+        .into();
 
-            let coefficients_uv: Simd<f64, 8> = [
-                0.528199646263062e3,
-                0.890579602135307e1,
-                -0.222814134903755,
-                0.286791682263697e-2,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-            ]
-            .into();
+        let coefficients_uv: Simd<f64, 8> = [
+            0.528199646263062e3,
+            0.890579602135307e1,
+            -0.222814134903755,
+            0.286791682263697e-2,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+        ]
+        .into();
 
-            let coefficients_wx: Simd<f64, 8> = [
-                0.728052609145380e1,
-                0.973505869861952e2,
-                0.147370491183191e2,
-                0.329196213998375e3,
-                0.873371668682417e3,
-                0.0,
-                0.0,
-                0.0,
-            ]
-            .into();
+        let coefficients_wx: Simd<f64, 8> = [
+            0.728052609145380e1,
+            0.973505869861952e2,
+            0.147370491183191e2,
+            0.329196213998375e3,
+            0.873371668682417e3,
+            0.0,
+            0.0,
+            0.0,
+        ]
+        .into();
 
-            let coefficients_rx: Simd<f64, 8> = [
-                0.584561202520006e3,
-                -0.102961025163669e1,
-                0.243293362700452,
-                -0.294905044740799e-2,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-            ]
-            .into();
+        let coefficients_rx: Simd<f64, 8> = [
+            0.584561202520006e3,
+            -0.102961025163669e1,
+            0.243293362700452,
+            -0.294905044740799e-2,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+        ]
+        .into();
 
-            let ii: [i32; 5] = [0, 1, 2, -1, -2];
-            let p_ln = (p * 1e-6).ln();
-            let (p_ln_base, p_base): ([f64; 5], [f64; 5]) = (
-                std::array::from_fn(|x| p_ln.powi(ii[x])),
-                std::array::from_fn(|x| (p * 1e-6).powi(x as i32)),
-            );
+        let ii: [i32; 5] = [0, 1, 2, -1, -2];
+        let p_ln = (p * 1e-6).ln();
+        let (p_ln_base, p_base): ([f64; 5], [f64; 5]) = (
+            std::array::from_fn(|x| p_ln.powi(ii[x])),
+            std::array::from_fn(|x| (p * 1e-6).powi(x as i32)),
+        );
 
-            let p_ln_base = Simd::<f64, 8>::load_or_default(&p_ln_base);
-            let p_base = Simd::<f64, 8>::load_or_default(&p_base);
+        let p_ln_base = Simd::<f64, 8>::load_or_default(&p_ln_base);
+        let p_base = Simd::<f64, 8>::load_or_default(&p_base);
 
-            let t_ab = (coefficients_ab * p_ln_base).reduce_sum();
-            let t_cd = (coefficients_cd * p_base).reduce_sum();
-            let t_ef = 3.727888004 * (p * 1e-6 - 22.064) + 647.096;
-            let t_gh = (coefficients_gh * p_base).reduce_sum();
-            let t_ij = (coefficients_ij * p_base).reduce_sum();
-            let t_jk = (coefficients_jk * p_base).reduce_sum();
-            let t_mn = (coefficients_mn * p_base).reduce_sum();
-            let t_op = (coefficients_op * p_ln_base).reduce_sum();
-            let t_qu = (coefficients_qu * p_base).reduce_sum();
-            let t_rx = (coefficients_rx * p_base).reduce_sum();
-            let t_uv = (coefficients_uv * p_base).reduce_sum();
-            let t_wx = (coefficients_wx * p_ln_base).reduce_sum();
-            (
-                t_ab, t_cd, t_ef, t_gh, t_ij, t_jk, t_mn, t_op, t_qu, t_rx, t_uv, t_wx,
-            )
-        } else {
-            let coefficients_ab: [f64; 5] = [
-                0.154793642129415e4,
-                -0.187661219490113e3,
-                0.213144632222113e2,
-                -0.191887498864292e4,
-                0.918419702359447e3,
-            ];
+        let t_ab = (coefficients_ab * p_ln_base).reduce_sum();
+        let t_cd = (coefficients_cd * p_base).reduce_sum();
+        let t_ef = 3.727888004 * (p * 1e-6 - 22.064) + 647.096;
+        let t_gh = (coefficients_gh * p_base).reduce_sum();
+        let t_ij = (coefficients_ij * p_base).reduce_sum();
+        let t_jk = (coefficients_jk * p_base).reduce_sum();
+        let t_mn = (coefficients_mn * p_base).reduce_sum();
+        let t_op = (coefficients_op * p_ln_base).reduce_sum();
+        let t_qu = (coefficients_qu * p_base).reduce_sum();
+        let t_rx = (coefficients_rx * p_base).reduce_sum();
+        let t_uv = (coefficients_uv * p_base).reduce_sum();
+        let t_wx = (coefficients_wx * p_ln_base).reduce_sum();
 
-            let coefficients_cd: [f64; 4] = [
-                0.585276966696349e3,
-                0.278233532206915e1,
-                -0.127283549295878e-1,
-                0.159090746562729e-3,
-            ];
-
-            let coefficients_gh: [f64; 5] = [
-                -0.249284240900418e5,
-                0.428143584791546e4,
-                -0.269029173140130e3,
-                0.751608051114157e1,
-                -0.787105249910383e-1,
-            ];
-
-            let coefficients_ij: [f64; 5] = [
-                0.584814781649163e3,
-                -0.616179320924617,
-                0.260763050899562,
-                -0.587071076864459e-2,
-                0.515308185433082e-4,
-            ];
-
-            let coefficients_jk: [f64; 5] = [
-                0.617229772068439e3,
-                -0.770600270141675e1,
-                0.697072596851896,
-                -0.157391839848015e-1,
-                0.137897492684194e-3,
-            ];
-
-            let coefficients_mn: [f64; 4] = [
-                0.535339483742384e3,
-                0.761978122720128e1,
-                -0.158365725441648,
-                0.192871054508108e-2,
-            ];
-
-            let coefficients_op: [f64; 5] = [
-                0.969461372400213e3,
-                -0.332500170441278e3,
-                0.642859598466067e2,
-                0.773845935768222e3,
-                -0.152313732937084e4,
-            ];
-
-            let coefficients_qu: [f64; 4] = [
-                0.565603648239126e3,
-                0.529062258221222e1,
-                -0.102020639611016,
-                0.122240301070145e-2,
-            ];
-
-            let coefficients_uv: [f64; 4] = [
-                0.528199646263062e3,
-                0.890579602135307e1,
-                -0.222814134903755,
-                0.286791682263697e-2,
-            ];
-
-            let coefficients_wx: [f64; 5] = [
-                0.728052609145380e1,
-                0.973505869861952e2,
-                0.147370491183191e2,
-                0.329196213998375e3,
-                0.873371668682417e3,
-            ];
-
-            let coefficients_rx: [f64; 4] = [
-                0.584561202520006e3,
-                -0.102961025163669e1,
-                0.243293362700452,
-                -0.294905044740799e-2,
-            ];
-
-            let ii: [i32; 5] = [0, 1, 2, -1, -2];
-
-            // Create variables for later use
-            let mut t_ab: f64 = 0.0;
-            let mut t_cd: f64 = 0.0;
-            let t_ef: f64 = 3.727888004 * ((p * 1e-6) - 22.064) + 647.096;
-            let mut t_gh: f64 = 0.0;
-            let mut t_ij: f64 = 0.0;
-            let mut t_jk: f64 = 0.0;
-            let mut t_mn: f64 = 0.0;
-            let mut t_op: f64 = 0.0;
-            let mut t_qu: f64 = 0.0;
-            let mut t_uv: f64 = 0.0;
-            let mut t_wx: f64 = 0.0;
-            let mut t_rx: f64 = 0.0;
-
-            // Calculate Boundaries
-            for x in 0..=4 {
-                if x <= 3 {
-                    t_cd += coefficients_cd[x] * (p * 1e-6).powi(x as i32);
-                    t_mn += coefficients_mn[x] * (p * 1e-6).powi(x as i32);
-                    t_qu += coefficients_qu[x] * (p * 1e-6).powi(x as i32);
-                    t_rx += coefficients_rx[x] * (p * 1e-6).powi(x as i32);
-                    t_uv += coefficients_uv[x] * (p * 1e-6).powi(x as i32)
-                }
-                t_ab += coefficients_ab[x] * ((p * 1e-6).ln()).powi(ii[x]);
-                t_gh += coefficients_gh[x] * (p * 1e-6).powi(x as i32);
-                t_ij += coefficients_ij[x] * (p * 1e-6).powi(x as i32);
-                t_jk += coefficients_jk[x] * (p * 1e-6).powi(x as i32);
-                t_op += coefficients_op[x] * ((p * 1e-6).ln()).powi(ii[x]);
-                t_wx += coefficients_wx[x] * ((p * 1e-6).ln()).powi(ii[x]);
+        // Calculate the Density
+        match (t, p) {
+            (temp, pres) if (40.0e6..=100.0e6).contains(&pres) && temp <= t_ab => {
+                Region3::SubregionA
             }
-            (
-                t_ab, t_cd, t_ef, t_gh, t_ij, t_jk, t_mn, t_op, t_qu, t_rx, t_uv, t_wx,
-            )
-        };
+            (temp, pres) if (40.0e6..=100.0e6).contains(&pres) && temp > t_ab => {
+                Region3::SubregionB
+            }
+            (temp, pres)
+                if ((19.00881189e6..=40.0e6).contains(&pres) && temp <= t_cd)
+                    || ((16.52916425e6..=19.008811889e6).contains(&pres)
+                        && temp <= tsat97(&pres)) =>
+            {
+                Region3::SubregionC
+            }
+            (temp, pres) if (25.0e6..=40.0e6).contains(&pres) && (t_cd..=t_ab).contains(&temp) => {
+                Region3::SubregionD
+            }
+            (temp, pres) if (25.0e6..=40.0e6).contains(&pres) && (t_ab..=t_ef).contains(&temp) => {
+                Region3::SubregionE
+            }
+            (temp, pres) if (25.0e6..=40.0e6).contains(&pres) && t_ef < temp => Region3::SubregionF,
+            (temp, pres) if (23.5e6..=25.0e6).contains(&pres) && (t_cd..=t_gh).contains(&temp) => {
+                Region3::SubregionG
+            }
+            (temp, pres) if (23.0e6..=25.0e6).contains(&pres) && (t_gh..=t_ef).contains(&temp) => {
+                Region3::SubregionH
+            }
+            (temp, pres) if (23.0e6..=25.0e6).contains(&pres) && (t_ef..=t_ij).contains(&temp) => {
+                Region3::SubregionI
+            }
+            (temp, pres) if (22.5e6..=25.0e6).contains(&pres) && (t_ij..=t_jk).contains(&temp) => {
+                Region3::SubregionJ
+            }
+            (temp, pres) if (20.5e6..=25.0e6).contains(&pres) && t_jk < temp => Region3::SubregionK,
+            (temp, pres) if (22.5e6..=23.5e6).contains(&pres) && (t_cd..=t_gh).contains(&temp) => {
+                Region3::SubregionL
+            }
+            (temp, pres) if (22.5e6..=23.0e6).contains(&pres) && (t_gh..=t_mn).contains(&temp) => {
+                Region3::SubregionM
+            }
+            (temp, pres) if (22.5e6..=23.0e6).contains(&pres) && (t_mn..=t_ef).contains(&temp) => {
+                Region3::SubregionN
+            }
+            (temp, pres) if (22.5e6..=23.0e6).contains(&pres) && (t_ef..=t_op).contains(&temp) => {
+                Region3::SubregionO
+            }
+            (temp, pres) if (22.5e6..=23.0e6).contains(&pres) && (t_op..=t_ij).contains(&temp) => {
+                Region3::SubregionP
+            }
+            (temp, pres)
+                if (21.04336732e6..=22.5e6).contains(&pres) && (t_cd..=t_qu).contains(&temp) =>
+            {
+                Region3::SubregionQ
+            }
+            (temp, pres)
+                if ((21.04336732e6..=22.5e6).contains(&pres) && (t_rx..=t_jk).contains(&temp))
+                    || ((20.5e6..=21.04336732e6).contains(&pres)
+                        && (tsat97(&pres)..=t_jk).contains(&temp)) =>
+            {
+                Region3::SubregionR
+            }
+            (temp, pres)
+                if (19.00881189e6..=21.04336732e6).contains(&pres)
+                    && (t_cd..=tsat97(&pres)).contains(&temp) =>
+            {
+                Region3::SubregionS
+            }
+            (temp, pres) if (16.52916425e6..=20.5e6).contains(&pres) && tsat97(&pres) < temp => {
+                Region3::SubregionT
+            }
+            (temp, pres)
+                if ((psat97(&temp)..=21.04336732e6).contains(&pres)
+                    && (t_qu..=tsat97(&pres)).contains(&temp))
+                    || ((21.04336732e6..=22.5e6).contains(&pres)
+                        && (t_qu..=t_uv).contains(&temp)) =>
+            {
+                Region3::SubregionU
+            }
+            (temp, pres) if (22.11e6..=22.5e6).contains(&pres) && (t_uv..=t_ef).contains(&temp) => {
+                Region3::SubregionV
+            }
+            (temp, pres) if (22.11e6..=22.5e6).contains(&pres) && (t_ef..=t_wx).contains(&temp) => {
+                Region3::SubregionW
+            }
+            (temp, pres)
+                if ((21.04336732e6..=22.5e6).contains(&pres) && (t_wx..=t_rx).contains(&temp))
+                    || ((psat97(&temp)..=21.04336732e6).contains(&pres)
+                        && (tsat97(&pres)..=t_rx).contains(&temp)) =>
+            {
+                Region3::SubregionX
+            }
+            (temp, pres)
+                if ((21.93161551e6..=22.11e6).contains(&pres) && (t_uv..=t_ef).contains(&temp))
+                    || ((psat97(&temp)..=21.93161551e6).contains(&pres)
+                        && (t_uv..=tsat97(&pres)).contains(&temp)) =>
+            {
+                Region3::SubregionY
+            }
+            _ => Region3::SubregionZ,
+        }
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
+        let coefficients_ab: [f64; 5] = [
+            0.154793642129415e4,
+            -0.187661219490113e3,
+            0.213144632222113e2,
+            -0.191887498864292e4,
+            0.918419702359447e3,
+        ];
 
-    // Calculate the Density
-    match (t, p) {
-        (temp, pres) if (40.0e6..=100.0e6).contains(&pres) && temp <= t_ab => Region3::SubregionA,
-        (temp, pres) if (40.0e6..=100.0e6).contains(&pres) && temp > t_ab => Region3::SubregionB,
-        (temp, pres)
-            if ((19.00881189e6..=40.0e6).contains(&pres) && temp <= t_cd)
-                || ((16.52916425e6..=19.008811889e6).contains(&pres) && temp <= tsat97(&pres)) =>
-        {
-            Region3::SubregionC
+        let coefficients_cd: [f64; 4] = [
+            0.585276966696349e3,
+            0.278233532206915e1,
+            -0.127283549295878e-1,
+            0.159090746562729e-3,
+        ];
+
+        let coefficients_gh: [f64; 5] = [
+            -0.249284240900418e5,
+            0.428143584791546e4,
+            -0.269029173140130e3,
+            0.751608051114157e1,
+            -0.787105249910383e-1,
+        ];
+
+        let coefficients_ij: [f64; 5] = [
+            0.584814781649163e3,
+            -0.616179320924617,
+            0.260763050899562,
+            -0.587071076864459e-2,
+            0.515308185433082e-4,
+        ];
+
+        let coefficients_jk: [f64; 5] = [
+            0.617229772068439e3,
+            -0.770600270141675e1,
+            0.697072596851896,
+            -0.157391839848015e-1,
+            0.137897492684194e-3,
+        ];
+
+        let coefficients_mn: [f64; 4] = [
+            0.535339483742384e3,
+            0.761978122720128e1,
+            -0.158365725441648,
+            0.192871054508108e-2,
+        ];
+
+        let coefficients_op: [f64; 5] = [
+            0.969461372400213e3,
+            -0.332500170441278e3,
+            0.642859598466067e2,
+            0.773845935768222e3,
+            -0.152313732937084e4,
+        ];
+
+        let coefficients_qu: [f64; 4] = [
+            0.565603648239126e3,
+            0.529062258221222e1,
+            -0.102020639611016,
+            0.122240301070145e-2,
+        ];
+
+        let coefficients_uv: [f64; 4] = [
+            0.528199646263062e3,
+            0.890579602135307e1,
+            -0.222814134903755,
+            0.286791682263697e-2,
+        ];
+
+        let coefficients_wx: [f64; 5] = [
+            0.728052609145380e1,
+            0.973505869861952e2,
+            0.147370491183191e2,
+            0.329196213998375e3,
+            0.873371668682417e3,
+        ];
+
+        let coefficients_rx: [f64; 4] = [
+            0.584561202520006e3,
+            -0.102961025163669e1,
+            0.243293362700452,
+            -0.294905044740799e-2,
+        ];
+
+        let ii: [i32; 5] = [0, 1, 2, -1, -2];
+
+        // Create variables for later use
+        let mut t_ab: f64 = 0.0;
+        let mut t_cd: f64 = 0.0;
+        let t_ef: f64 = 3.727888004 * ((p * 1e-6) - 22.064) + 647.096;
+        let mut t_gh: f64 = 0.0;
+        let mut t_ij: f64 = 0.0;
+        let mut t_jk: f64 = 0.0;
+        let mut t_mn: f64 = 0.0;
+        let mut t_op: f64 = 0.0;
+        let mut t_qu: f64 = 0.0;
+        let mut t_uv: f64 = 0.0;
+        let mut t_wx: f64 = 0.0;
+        let mut t_rx: f64 = 0.0;
+
+        // Calculate Boundaries
+        for x in 0..=4 {
+            if x <= 3 {
+                t_cd += coefficients_cd[x] * (p * 1e-6).powi(x as i32);
+                t_mn += coefficients_mn[x] * (p * 1e-6).powi(x as i32);
+                t_qu += coefficients_qu[x] * (p * 1e-6).powi(x as i32);
+                t_rx += coefficients_rx[x] * (p * 1e-6).powi(x as i32);
+                t_uv += coefficients_uv[x] * (p * 1e-6).powi(x as i32)
+            }
+            t_ab += coefficients_ab[x] * ((p * 1e-6).ln()).powi(ii[x]);
+            t_gh += coefficients_gh[x] * (p * 1e-6).powi(x as i32);
+            t_ij += coefficients_ij[x] * (p * 1e-6).powi(x as i32);
+            t_jk += coefficients_jk[x] * (p * 1e-6).powi(x as i32);
+            t_op += coefficients_op[x] * ((p * 1e-6).ln()).powi(ii[x]);
+            t_wx += coefficients_wx[x] * ((p * 1e-6).ln()).powi(ii[x]);
         }
-        (temp, pres) if (25.0e6..=40.0e6).contains(&pres) && (t_cd..=t_ab).contains(&temp) => {
-            Region3::SubregionD
+
+        // Calculate the Density
+        match (t, p) {
+            (temp, pres) if (40.0e6..=100.0e6).contains(&pres) && temp <= t_ab => {
+                Region3::SubregionA
+            }
+            (temp, pres) if (40.0e6..=100.0e6).contains(&pres) && temp > t_ab => {
+                Region3::SubregionB
+            }
+            (temp, pres)
+                if ((19.00881189e6..=40.0e6).contains(&pres) && temp <= t_cd)
+                    || ((16.52916425e6..=19.008811889e6).contains(&pres)
+                        && temp <= tsat97(&pres)) =>
+            {
+                Region3::SubregionC
+            }
+            (temp, pres) if (25.0e6..=40.0e6).contains(&pres) && (t_cd..=t_ab).contains(&temp) => {
+                Region3::SubregionD
+            }
+            (temp, pres) if (25.0e6..=40.0e6).contains(&pres) && (t_ab..=t_ef).contains(&temp) => {
+                Region3::SubregionE
+            }
+            (temp, pres) if (25.0e6..=40.0e6).contains(&pres) && t_ef < temp => Region3::SubregionF,
+            (temp, pres) if (23.5e6..=25.0e6).contains(&pres) && (t_cd..=t_gh).contains(&temp) => {
+                Region3::SubregionG
+            }
+            (temp, pres) if (23.0e6..=25.0e6).contains(&pres) && (t_gh..=t_ef).contains(&temp) => {
+                Region3::SubregionH
+            }
+            (temp, pres) if (23.0e6..=25.0e6).contains(&pres) && (t_ef..=t_ij).contains(&temp) => {
+                Region3::SubregionI
+            }
+            (temp, pres) if (22.5e6..=25.0e6).contains(&pres) && (t_ij..=t_jk).contains(&temp) => {
+                Region3::SubregionJ
+            }
+            (temp, pres) if (20.5e6..=25.0e6).contains(&pres) && t_jk < temp => Region3::SubregionK,
+            (temp, pres) if (22.5e6..=23.5e6).contains(&pres) && (t_cd..=t_gh).contains(&temp) => {
+                Region3::SubregionL
+            }
+            (temp, pres) if (22.5e6..=23.0e6).contains(&pres) && (t_gh..=t_mn).contains(&temp) => {
+                Region3::SubregionM
+            }
+            (temp, pres) if (22.5e6..=23.0e6).contains(&pres) && (t_mn..=t_ef).contains(&temp) => {
+                Region3::SubregionN
+            }
+            (temp, pres) if (22.5e6..=23.0e6).contains(&pres) && (t_ef..=t_op).contains(&temp) => {
+                Region3::SubregionO
+            }
+            (temp, pres) if (22.5e6..=23.0e6).contains(&pres) && (t_op..=t_ij).contains(&temp) => {
+                Region3::SubregionP
+            }
+            (temp, pres)
+                if (21.04336732e6..=22.5e6).contains(&pres) && (t_cd..=t_qu).contains(&temp) =>
+            {
+                Region3::SubregionQ
+            }
+            (temp, pres)
+                if ((21.04336732e6..=22.5e6).contains(&pres) && (t_rx..=t_jk).contains(&temp))
+                    || ((20.5e6..=21.04336732e6).contains(&pres)
+                        && (tsat97(&pres)..=t_jk).contains(&temp)) =>
+            {
+                Region3::SubregionR
+            }
+            (temp, pres)
+                if (19.00881189e6..=21.04336732e6).contains(&pres)
+                    && (t_cd..=tsat97(&pres)).contains(&temp) =>
+            {
+                Region3::SubregionS
+            }
+            (temp, pres) if (16.52916425e6..=20.5e6).contains(&pres) && tsat97(&pres) < temp => {
+                Region3::SubregionT
+            }
+            (temp, pres)
+                if ((psat97(&temp)..=21.04336732e6).contains(&pres)
+                    && (t_qu..=tsat97(&pres)).contains(&temp))
+                    || ((21.04336732e6..=22.5e6).contains(&pres)
+                        && (t_qu..=t_uv).contains(&temp)) =>
+            {
+                Region3::SubregionU
+            }
+            (temp, pres) if (22.11e6..=22.5e6).contains(&pres) && (t_uv..=t_ef).contains(&temp) => {
+                Region3::SubregionV
+            }
+            (temp, pres) if (22.11e6..=22.5e6).contains(&pres) && (t_ef..=t_wx).contains(&temp) => {
+                Region3::SubregionW
+            }
+            (temp, pres)
+                if ((21.04336732e6..=22.5e6).contains(&pres) && (t_wx..=t_rx).contains(&temp))
+                    || ((psat97(&temp)..=21.04336732e6).contains(&pres)
+                        && (tsat97(&pres)..=t_rx).contains(&temp)) =>
+            {
+                Region3::SubregionX
+            }
+            (temp, pres)
+                if ((21.93161551e6..=22.11e6).contains(&pres) && (t_uv..=t_ef).contains(&temp))
+                    || ((psat97(&temp)..=21.93161551e6).contains(&pres)
+                        && (t_uv..=tsat97(&pres)).contains(&temp)) =>
+            {
+                Region3::SubregionY
+            }
+            _ => Region3::SubregionZ,
         }
-        (temp, pres) if (25.0e6..=40.0e6).contains(&pres) && (t_ab..=t_ef).contains(&temp) => {
-            Region3::SubregionE
-        }
-        (temp, pres) if (25.0e6..=40.0e6).contains(&pres) && t_ef < temp => Region3::SubregionF,
-        (temp, pres) if (23.5e6..=25.0e6).contains(&pres) && (t_cd..=t_gh).contains(&temp) => {
-            Region3::SubregionG
-        }
-        (temp, pres) if (23.0e6..=25.0e6).contains(&pres) && (t_gh..=t_ef).contains(&temp) => {
-            Region3::SubregionH
-        }
-        (temp, pres) if (23.0e6..=25.0e6).contains(&pres) && (t_ef..=t_ij).contains(&temp) => {
-            Region3::SubregionI
-        }
-        (temp, pres) if (22.5e6..=25.0e6).contains(&pres) && (t_ij..=t_jk).contains(&temp) => {
-            Region3::SubregionJ
-        }
-        (temp, pres) if (20.5e6..=25.0e6).contains(&pres) && t_jk < temp => Region3::SubregionK,
-        (temp, pres) if (22.5e6..=23.5e6).contains(&pres) && (t_cd..=t_gh).contains(&temp) => {
-            Region3::SubregionL
-        }
-        (temp, pres) if (22.5e6..=23.0e6).contains(&pres) && (t_gh..=t_mn).contains(&temp) => {
-            Region3::SubregionM
-        }
-        (temp, pres) if (22.5e6..=23.0e6).contains(&pres) && (t_mn..=t_ef).contains(&temp) => {
-            Region3::SubregionN
-        }
-        (temp, pres) if (22.5e6..=23.0e6).contains(&pres) && (t_ef..=t_op).contains(&temp) => {
-            Region3::SubregionO
-        }
-        (temp, pres) if (22.5e6..=23.0e6).contains(&pres) && (t_op..=t_ij).contains(&temp) => {
-            Region3::SubregionP
-        }
-        (temp, pres)
-            if (21.04336732e6..=22.5e6).contains(&pres) && (t_cd..=t_qu).contains(&temp) =>
-        {
-            Region3::SubregionQ
-        }
-        (temp, pres)
-            if ((21.04336732e6..=22.5e6).contains(&pres) && (t_rx..=t_jk).contains(&temp))
-                || ((20.5e6..=21.04336732e6).contains(&pres)
-                    && (tsat97(&pres)..=t_jk).contains(&temp)) =>
-        {
-            Region3::SubregionR
-        }
-        (temp, pres)
-            if (19.00881189e6..=21.04336732e6).contains(&pres)
-                && (t_cd..=tsat97(&pres)).contains(&temp) =>
-        {
-            Region3::SubregionS
-        }
-        (temp, pres) if (16.52916425e6..=20.5e6).contains(&pres) && tsat97(&pres) < temp => {
-            Region3::SubregionT
-        }
-        (temp, pres)
-            if ((psat97(&temp)..=21.04336732e6).contains(&pres)
-                && (t_qu..=tsat97(&pres)).contains(&temp))
-                || ((21.04336732e6..=22.5e6).contains(&pres) && (t_qu..=t_uv).contains(&temp)) =>
-        {
-            Region3::SubregionU
-        }
-        (temp, pres) if (22.11e6..=22.5e6).contains(&pres) && (t_uv..=t_ef).contains(&temp) => {
-            Region3::SubregionV
-        }
-        (temp, pres) if (22.11e6..=22.5e6).contains(&pres) && (t_ef..=t_wx).contains(&temp) => {
-            Region3::SubregionW
-        }
-        (temp, pres)
-            if ((21.04336732e6..=22.5e6).contains(&pres) && (t_wx..=t_rx).contains(&temp))
-                || ((psat97(&temp)..=21.04336732e6).contains(&pres)
-                    && (tsat97(&pres)..=t_rx).contains(&temp)) =>
-        {
-            Region3::SubregionX
-        }
-        (temp, pres)
-            if ((21.93161551e6..=22.11e6).contains(&pres) && (t_uv..=t_ef).contains(&temp))
-                || ((psat97(&temp)..=21.93161551e6).contains(&pres)
-                    && (t_uv..=tsat97(&pres)).contains(&temp)) =>
-        {
-            Region3::SubregionY
-        }
-        _ => Region3::SubregionZ,
     }
 }
 
@@ -2289,7 +2472,8 @@ fn tau_3(t: f64) -> f64 {
 fn phi_3(rho: f64, t: f64) -> f64 {
     let tau: f64 = tau_3(t);
     let delta: f64 = delta_3(rho);
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (delta, tau): ([f64; 39], [f64; 39]) = (
             std::array::from_fn(|x| delta.powi(REGION_3_COEFFS_II[x + 1])),
             std::array::from_fn(|x| tau.powi(REGION_3_COEFFS_JI[x + 1])),
@@ -2300,7 +2484,9 @@ fn phi_3(rho: f64, t: f64) -> f64 {
         let tau = Simd::<f64, 64>::load_or_default(&tau);
 
         (ni * delta * tau).reduce_sum() + REGION_3_COEFFS_NI[0] * delta_3(rho).ln()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let mut sum: f64 = 0.0_f64;
         for x in 1..REGION_3_COEFFS_II.len() {
             let ii = REGION_3_COEFFS_II[x];
@@ -2318,7 +2504,8 @@ fn phi_3(rho: f64, t: f64) -> f64 {
 fn phi_delta_3(rho: f64, t: f64) -> f64 {
     let tau: f64 = tau_3(t);
     let delta_3: f64 = delta_3(rho);
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (delta, tau): ([f64; 39], [f64; 39]) = (
             std::array::from_fn(|x| delta_3.powi(REGION_3_COEFFS_II[x + 1] - 1)),
             std::array::from_fn(|x| tau.powi(REGION_3_COEFFS_JI[x + 1])),
@@ -2330,7 +2517,9 @@ fn phi_delta_3(rho: f64, t: f64) -> f64 {
         let tau = Simd::<f64, 64>::load_or_default(&tau);
 
         (ni * ii * delta * tau).reduce_sum() + REGION_3_COEFFS_NI[0] / delta_3
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let mut sum: f64 = 0.0_f64;
         for x in 1..REGION_3_COEFFS_II.len() {
             let ii = REGION_3_COEFFS_II[x];
@@ -2348,7 +2537,8 @@ fn phi_delta_3(rho: f64, t: f64) -> f64 {
 fn phi_delta_delta_3(rho: f64, t: f64) -> f64 {
     let tau: f64 = tau_3(t);
     let delta_3: f64 = delta_3(rho);
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (delta, tau): ([f64; 39], [f64; 39]) = (
             std::array::from_fn(|x| delta_3.powi(REGION_3_COEFFS_II[x + 1] - 2)),
             std::array::from_fn(|x| tau.powi(REGION_3_COEFFS_JI[x + 1])),
@@ -2361,7 +2551,9 @@ fn phi_delta_delta_3(rho: f64, t: f64) -> f64 {
 
         (ni * ii * (ii - f64x64::splat(1.0)) * delta * tau).reduce_sum()
             - REGION_3_COEFFS_NI[0] / delta_3.powi(2)
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let mut sum: f64 = 0.0_f64;
         for x in 1..REGION_3_COEFFS_II.len() {
             let ii = REGION_3_COEFFS_II[x];
@@ -2379,7 +2571,8 @@ fn phi_delta_delta_3(rho: f64, t: f64) -> f64 {
 fn phi_tau_3(rho: f64, t: f64) -> f64 {
     let tau: f64 = tau_3(t);
     let delta_3: f64 = delta_3(rho);
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (delta, tau): ([f64; 39], [f64; 39]) = (
             std::array::from_fn(|x| delta_3.powi(REGION_3_COEFFS_II[x + 1])),
             std::array::from_fn(|x| tau.powi(REGION_3_COEFFS_JI[x + 1] - 1)),
@@ -2391,7 +2584,9 @@ fn phi_tau_3(rho: f64, t: f64) -> f64 {
         let tau = Simd::<f64, 64>::load_or_default(&tau);
 
         (ni * ji * delta * tau).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let mut sum: f64 = 0.0_f64;
         for x in 1..REGION_3_COEFFS_II.len() {
             let ii = REGION_3_COEFFS_II[x];
@@ -2409,7 +2604,8 @@ fn phi_tau_3(rho: f64, t: f64) -> f64 {
 fn phi_tau_tau_3(rho: f64, t: f64) -> f64 {
     let tau: f64 = tau_3(t);
     let delta_3: f64 = delta_3(rho);
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (delta, tau): ([f64; 39], [f64; 39]) = (
             std::array::from_fn(|x| delta_3.powi(REGION_3_COEFFS_II[x + 1])),
             std::array::from_fn(|x| tau.powi(REGION_3_COEFFS_JI[x + 1] - 2)),
@@ -2421,7 +2617,9 @@ fn phi_tau_tau_3(rho: f64, t: f64) -> f64 {
         let tau = Simd::<f64, 64>::load_or_default(&tau);
 
         (ni * ji * (ji - f64x64::splat(1.0)) * delta * tau).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let mut sum: f64 = 0.0_f64;
         for x in 1..REGION_3_COEFFS_II.len() {
             let ii = REGION_3_COEFFS_II[x];
@@ -2439,7 +2637,8 @@ fn phi_tau_tau_3(rho: f64, t: f64) -> f64 {
 fn phi_delta_tau_3(rho: f64, t: f64) -> f64 {
     let tau: f64 = tau_3(t);
     let delta_3: f64 = delta_3(rho);
-    if cfg!(feature = "nightly") {
+    #[cfg(feature = "nightly")]
+    {
         let (delta, tau): ([f64; 39], [f64; 39]) = (
             std::array::from_fn(|x| delta_3.powi(REGION_3_COEFFS_II[x + 1] - 1)),
             std::array::from_fn(|x| tau.powi(REGION_3_COEFFS_JI[x + 1] - 1)),
@@ -2452,7 +2651,9 @@ fn phi_delta_tau_3(rho: f64, t: f64) -> f64 {
         let tau = Simd::<f64, 64>::load_or_default(&tau);
 
         (ni * ji * ii * delta * tau).reduce_sum()
-    } else {
+    }
+    #[cfg(not(feature = "nightly"))]
+    {
         let mut sum: f64 = 0.0_f64;
         for x in 1..REGION_3_COEFFS_II.len() {
             let ii = REGION_3_COEFFS_II[x];

--- a/src/iapws97/region_3.rs
+++ b/src/iapws97/region_3.rs
@@ -1924,6 +1924,7 @@ fn phi_delta_tau_3(rho: f64, t: f64) -> f64 {
 /// Temperature is assumed to be in K
 /// density is assumed to be in kg/m^3
 #[allow(dead_code)]
+#[inline]
 fn p_rho_t_3(rho: f64, t: f64) -> f64 {
     rho * (constants::_R * 1000.0) * t * delta_3(rho) * phi_delta_3(rho, t)
 }
@@ -1931,6 +1932,7 @@ fn p_rho_t_3(rho: f64, t: f64) -> f64 {
 /// Returns the internal energy given t and rho
 /// Temperature is assumed to be in K
 /// density is assumed to be in kg/m^3
+#[inline]
 fn u_rho_t_3(rho: f64, t: f64) -> f64 {
     tau_3(t) * phi_tau_3(rho, t) * constants::_R * t
 }
@@ -1938,6 +1940,7 @@ fn u_rho_t_3(rho: f64, t: f64) -> f64 {
 /// Returns the entropy given t and rho
 /// Temperature is assumed to be in K
 /// density is assumed to be in kg/m^3
+#[inline]
 fn s_rho_t_3(rho: f64, t: f64) -> f64 {
     (tau_3(t) * phi_tau_3(rho, t) - phi_3(rho, t)) * constants::_R
 }
@@ -1945,6 +1948,7 @@ fn s_rho_t_3(rho: f64, t: f64) -> f64 {
 /// Returns the enthalpy given t and rho
 /// Temperature is assumed to be in K
 /// density is assumed to be in kg/m^3
+#[inline]
 fn h_rho_t_3(rho: f64, t: f64) -> f64 {
     (tau_3(t) * phi_tau_3(rho, t) + delta_3(rho) * phi_delta_3(rho, t)) * constants::_R * t
 }
@@ -1952,6 +1956,7 @@ fn h_rho_t_3(rho: f64, t: f64) -> f64 {
 /// Returns the isochoric specific heat given t and rho
 /// Temperature is assumed to be in K
 /// density is assumed to be in kg/m^3
+#[inline]
 fn cv_rho_t_3(rho: f64, t: f64) -> f64 {
     -tau_3(t).powi(2) * phi_tau_tau_3(rho, t) * constants::_R
 }
@@ -1959,6 +1964,7 @@ fn cv_rho_t_3(rho: f64, t: f64) -> f64 {
 /// Returns the isobaric specific heat given t and rho
 /// Temperature is assumed to be in K
 /// density is assumed to be in kg/m^3
+#[inline]
 fn cp_rho_t_3(rho: f64, t: f64) -> f64 {
     (-tau_3(t).powi(2) * phi_tau_tau_3(rho, t)
         + ((delta_3(rho) * phi_delta_3(rho, t)
@@ -1969,7 +1975,7 @@ fn cp_rho_t_3(rho: f64, t: f64) -> f64 {
         * constants::_R
 }
 
-#[allow(dead_code)]
+#[inline]
 fn w_rho_t_3(rho: f64, t: f64) -> f64 {
     ((2.0 * delta_3(rho) * phi_delta_3(rho, t) + delta_3(rho).powi(2) * phi_delta_delta_3(rho, t)
         - ((delta_3(rho) * phi_delta_3(rho, t)
@@ -1985,6 +1991,7 @@ fn w_rho_t_3(rho: f64, t: f64) -> f64 {
 /// Returns the specific volume given t and rho
 /// Temperature is assumed to be in K
 /// density is assumed to be in kg/m^3
+#[inline]
 pub(crate) fn v_tp_3(t: f64, p: f64) -> f64 {
     match subregion(t, p) {
         Region3::SubregionA => subregion_a(t, p),
@@ -2016,32 +2023,37 @@ pub(crate) fn v_tp_3(t: f64, p: f64) -> f64 {
     }
 }
 
+#[inline]
 pub(crate) fn cv_tp_3(t: f64, p: f64) -> f64 {
     let rho: f64 = (v_tp_3(t, p)).powi(-1);
     cv_rho_t_3(rho, t)
 }
 
+#[inline]
 pub(crate) fn cp_tp_3(t: f64, p: f64) -> f64 {
     let rho: f64 = (v_tp_3(t, p)).powi(-1);
     cp_rho_t_3(rho, t)
 }
 
+#[inline]
 pub(crate) fn s_tp_3(t: f64, p: f64) -> f64 {
     let rho: f64 = (v_tp_3(t, p)).powi(-1);
     s_rho_t_3(rho, t)
 }
 
+#[inline]
 pub(crate) fn u_tp_3(t: f64, p: f64) -> f64 {
     let rho: f64 = (v_tp_3(t, p)).powi(-1);
     u_rho_t_3(rho, t)
 }
 
+#[inline]
 pub(crate) fn h_tp_3(t: f64, p: f64) -> f64 {
     let rho: f64 = (v_tp_3(t, p)).powi(-1);
     h_rho_t_3(rho, t)
 }
 
-#[allow(dead_code)]
+#[inline]
 pub fn w_tp_3(t: f64, p: f64) -> f64 {
     let rho: f64 = (v_tp_3(t, p)).powi(-1);
     w_rho_t_3(rho, t)

--- a/src/iapws97/region_3.rs
+++ b/src/iapws97/region_3.rs
@@ -1,4 +1,5 @@
 use crate::iapws97::{constants, psat97};
+use std::simd::prelude::*;
 
 use super::tsat97;
 
@@ -133,12 +134,25 @@ fn subregion_a(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 30] = core::array::from_fn(|i| i);
-    let v: f64 = x
-        .into_iter()
-        .map(|x| n[x] * (((p * 1e-8) - 0.085).powi(i[x]) * ((t / 760.0) - 0.817).powi(j[x])))
-        .sum();
-    v * 0.0024
+    if cfg!(feature = "nightly") {
+        let (p_base, t_base): ([f64; 30], [f64; 30]) = (
+            std::array::from_fn(|x| ((p * 1e-8) - 0.085).powi(i[x])),
+            std::array::from_fn(|x| ((t / 760.0) - 0.817).powi(j[x])),
+        );
+
+        let n = Simd::<f64, 32>::load_or_default(&n);
+        let t_base = Simd::<f64, 32>::load_or_default(&t_base);
+        let p_base = Simd::<f64, 32>::load_or_default(&p_base);
+
+        0.0024 * (n * p_base * t_base).reduce_sum()
+    } else {
+        let x: [usize; 30] = core::array::from_fn(|i| i);
+        let v: f64 = x
+            .into_iter()
+            .map(|x| n[x] * (((p * 1e-8) - 0.085).powi(i[x]) * ((t / 760.0) - 0.817).powi(j[x])))
+            .sum();
+        v * 0.0024
+    }
 }
 
 fn subregion_b(t: f64, p: f64) -> f64 {
@@ -188,12 +202,25 @@ fn subregion_b(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 32] = core::array::from_fn(|i| i);
-    let v: f64 = x
-        .into_iter()
-        .map(|x| n[x] * (((p * 1e-8) - 0.280).powi(i[x]) * ((t / 860.0) - 0.779).powi(j[x])))
-        .sum();
-    v * 0.0041
+    if cfg!(feature = "nightly") {
+        let (p_base, t_base): ([f64; 32], [f64; 32]) = (
+            std::array::from_fn(|x| ((p * 1e-8) - 0.280).powi(i[x])),
+            std::array::from_fn(|x| ((t / 860.0) - 0.779).powi(j[x])),
+        );
+
+        let n = Simd::<f64, 32>::load_or_default(&n);
+        let t_base = Simd::<f64, 32>::load_or_default(&t_base);
+        let p_base = Simd::<f64, 32>::load_or_default(&p_base);
+
+        0.0041 * (n * p_base * t_base).reduce_sum()
+    } else {
+        let x: [usize; 32] = core::array::from_fn(|i| i);
+        let v: f64 = x
+            .into_iter()
+            .map(|x| n[x] * (((p * 1e-8) - 0.280).powi(i[x]) * ((t / 860.0) - 0.779).powi(j[x])))
+            .sum();
+        v * 0.0041
+    }
 }
 
 fn subregion_c(t: f64, p: f64) -> f64 {
@@ -246,12 +273,25 @@ fn subregion_c(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 35] = core::array::from_fn(|i| i);
-    let v: f64 = x
-        .into_iter()
-        .map(|x| n[x] * (((p * 2.5e-8) - 0.259).powi(i[x]) * ((t / 690.0) - 0.903).powi(j[x])))
-        .sum();
-    v * 0.0022
+    if cfg!(feature = "nightly") {
+        let (p_base, t_base): ([f64; 35], [f64; 35]) = (
+            std::array::from_fn(|x| ((p * 2.5e-8) - 0.259).powi(i[x])),
+            std::array::from_fn(|x| ((t / 690.0) - 0.903).powi(j[x])),
+        );
+
+        let n = Simd::<f64, 64>::load_or_default(&n);
+        let t_base = Simd::<f64, 64>::load_or_default(&t_base);
+        let p_base = Simd::<f64, 64>::load_or_default(&p_base);
+
+        0.0022 * (n * p_base * t_base).reduce_sum()
+    } else {
+        let x: [usize; 35] = core::array::from_fn(|i| i);
+        let v: f64 = x
+            .into_iter()
+            .map(|x| n[x] * (((p * 2.5e-8) - 0.259).powi(i[x]) * ((t / 690.0) - 0.903).powi(j[x])))
+            .sum();
+        v * 0.0022
+    }
 }
 
 fn subregion_d(t: f64, p: f64) -> f64 {
@@ -307,12 +347,25 @@ fn subregion_d(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 38] = core::array::from_fn(|i| i);
-    let v: f64 = x
-        .into_iter()
-        .map(|x| n[x] * (((p * 2.5e-8) - 0.559).powi(i[x]) * ((t / 690.0) - 0.939).powi(j[x])))
-        .sum();
-    v.powi(4) * 0.0029
+    if cfg!(feature = "nightly") {
+        let (p_base, t_base): ([f64; 38], [f64; 38]) = (
+            std::array::from_fn(|x| ((p * 2.5e-8) - 0.559).powi(i[x])),
+            std::array::from_fn(|x| ((t / 690.0) - 0.939).powi(j[x])),
+        );
+
+        let n = Simd::<f64, 64>::load_or_default(&n);
+        let t_base = Simd::<f64, 64>::load_or_default(&t_base);
+        let p_base = Simd::<f64, 64>::load_or_default(&p_base);
+
+        0.0029 * ((n * p_base * t_base).reduce_sum()).powi(4)
+    } else {
+        let x: [usize; 38] = core::array::from_fn(|i| i);
+        let v: f64 = x
+            .into_iter()
+            .map(|x| n[x] * (((p * 2.5e-8) - 0.559).powi(i[x]) * ((t / 690.0) - 0.939).powi(j[x])))
+            .sum();
+        v.powi(4) * 0.0029
+    }
 }
 
 fn subregion_e(t: f64, p: f64) -> f64 {
@@ -358,12 +411,25 @@ fn subregion_e(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 29] = core::array::from_fn(|i| i);
-    let v: f64 = x
-        .into_iter()
-        .map(|x| n[x] * (((p * 2.5e-8) - 0.587).powi(i[x]) * ((t / 710.0) - 0.918).powi(j[x])))
-        .sum();
-    v * 0.0032
+    if cfg!(feature = "nightly") {
+        let (p_base, t_base): ([f64; 29], [f64; 29]) = (
+            std::array::from_fn(|x| ((p * 2.5e-8) - 0.587).powi(i[x])),
+            std::array::from_fn(|x| ((t / 710.0) - 0.918).powi(j[x])),
+        );
+
+        let n = Simd::<f64, 32>::load_or_default(&n);
+        let t_base = Simd::<f64, 32>::load_or_default(&t_base);
+        let p_base = Simd::<f64, 32>::load_or_default(&p_base);
+
+        0.0032 * (n * p_base * t_base).reduce_sum()
+    } else {
+        let x: [usize; 29] = core::array::from_fn(|i| i);
+        let v: f64 = x
+            .into_iter()
+            .map(|x| n[x] * (((p * 2.5e-8) - 0.587).powi(i[x]) * ((t / 710.0) - 0.918).powi(j[x])))
+            .sum();
+        v * 0.0032
+    }
 }
 
 fn subregion_f(t: f64, p: f64) -> f64 {
@@ -423,15 +489,28 @@ fn subregion_f(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 42] = core::array::from_fn(|i| i);
-    let v: f64 = x
-        .into_iter()
-        .map(|x| {
-            n[x] * ((((p * 002.5e-8) - 0.587).powf(0.5)).powi(i[x])
-                * ((t / 730.0) - 0.891).powi(j[x]))
-        })
-        .sum();
-    v.powi(4) * 0.0064
+    if cfg!(feature = "nightly") {
+        let (p_base, t_base): ([f64; 42], [f64; 42]) = (
+            std::array::from_fn(|x| (((p * 2.5e-8) - 0.587).powf(0.5)).powi(i[x])),
+            std::array::from_fn(|x| ((t / 730.0) - 0.891).powi(j[x])),
+        );
+
+        let n = Simd::<f64, 64>::load_or_default(&n);
+        let t_base = Simd::<f64, 64>::load_or_default(&t_base);
+        let p_base = Simd::<f64, 64>::load_or_default(&p_base);
+
+        0.0064 * ((n * p_base * t_base).reduce_sum()).powi(4)
+    } else {
+        let x: [usize; 42] = core::array::from_fn(|i| i);
+        let v: f64 = x
+            .into_iter()
+            .map(|x| {
+                n[x] * ((((p * 002.5e-8) - 0.587).powf(0.5)).powi(i[x])
+                    * ((t / 730.0) - 0.891).powi(j[x]))
+            })
+            .sum();
+        v.powi(4) * 0.0064
+    }
 }
 
 fn subregion_g(t: f64, p: f64) -> f64 {
@@ -487,12 +566,25 @@ fn subregion_g(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 38] = core::array::from_fn(|i| i);
-    let v: f64 = x
-        .into_iter()
-        .map(|x| n[x] * (((p * 4.0e-8) - 0.872).powi(i[x]) * ((t / 660.0) - 0.971).powi(j[x])))
-        .sum();
-    v.powi(4) * 0.0027
+    if cfg!(feature = "nightly") {
+        let (p_base, t_base): ([f64; 38], [f64; 38]) = (
+            std::array::from_fn(|x| ((p * 4.0e-8) - 0.872).powi(i[x])),
+            std::array::from_fn(|x| ((t / 660.0) - 0.971).powi(j[x])),
+        );
+
+        let n = Simd::<f64, 64>::load_or_default(&n);
+        let t_base = Simd::<f64, 64>::load_or_default(&t_base);
+        let p_base = Simd::<f64, 64>::load_or_default(&p_base);
+
+        0.0027 * ((n * p_base * t_base).reduce_sum()).powi(4)
+    } else {
+        let x: [usize; 38] = core::array::from_fn(|i| i);
+        let v: f64 = x
+            .into_iter()
+            .map(|x| n[x] * (((p * 4.0e-8) - 0.872).powi(i[x]) * ((t / 660.0) - 0.971).powi(j[x])))
+            .sum();
+        v.powi(4) * 0.0027
+    }
 }
 
 fn subregion_h(t: f64, p: f64) -> f64 {
@@ -538,12 +630,25 @@ fn subregion_h(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 29] = core::array::from_fn(|i| i);
-    let v: f64 = x
-        .into_iter()
-        .map(|x| n[x] * (((p * 4.0e-8) - 0.898).powi(i[x]) * ((t / 660.0) - 0.983).powi(j[x])))
-        .sum();
-    v.powi(4) * 0.0032
+    if cfg!(feature = "nightly") {
+        let (p_base, t_base): ([f64; 29], [f64; 29]) = (
+            std::array::from_fn(|x| ((p * 4.0e-8) - 0.898).powi(i[x])),
+            std::array::from_fn(|x| ((t / 660.0) - 0.983).powi(j[x])),
+        );
+
+        let n = Simd::<f64, 32>::load_or_default(&n);
+        let t_base = Simd::<f64, 32>::load_or_default(&t_base);
+        let p_base = Simd::<f64, 32>::load_or_default(&p_base);
+
+        0.0032 * ((n * p_base * t_base).reduce_sum()).powi(4)
+    } else {
+        let x: [usize; 29] = core::array::from_fn(|i| i);
+        let v: f64 = x
+            .into_iter()
+            .map(|x| n[x] * (((p * 4.0e-8) - 0.898).powi(i[x]) * ((t / 660.0) - 0.983).powi(j[x])))
+            .sum();
+        v.powi(4) * 0.0032
+    }
 }
 
 fn subregion_i(t: f64, p: f64) -> f64 {
@@ -603,15 +708,28 @@ fn subregion_i(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 42] = core::array::from_fn(|i| i);
-    let v: f64 = x
-        .into_iter()
-        .map(|x| {
-            n[x] * ((((p * 4.0e-8) - 0.910).powf(0.5)).powi(i[x])
-                * ((t / 660.0) - 0.984).powi(j[x]))
-        })
-        .sum();
-    v.powi(4) * 0.0041
+    if cfg!(feature = "nightly") {
+        let (p_base, t_base): ([f64; 42], [f64; 42]) = (
+            std::array::from_fn(|x| (((p * 4.0e-8) - 0.910).powf(0.5)).powi(i[x])),
+            std::array::from_fn(|x| ((t / 660.0) - 0.984).powi(j[x])),
+        );
+
+        let n = Simd::<f64, 64>::load_or_default(&n);
+        let t_base = Simd::<f64, 64>::load_or_default(&t_base);
+        let p_base = Simd::<f64, 64>::load_or_default(&p_base);
+
+        0.0041 * ((n * p_base * t_base).reduce_sum()).powi(4)
+    } else {
+        let x: [usize; 42] = core::array::from_fn(|i| i);
+        let v: f64 = x
+            .into_iter()
+            .map(|x| {
+                n[x] * ((((p * 4.0e-8) - 0.910).powf(0.5)).powi(i[x])
+                    * ((t / 660.0) - 0.984).powi(j[x]))
+            })
+            .sum();
+        v.powi(4) * 0.0041
+    }
 }
 
 fn subregion_j(t: f64, p: f64) -> f64 {
@@ -658,15 +776,28 @@ fn subregion_j(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 29] = core::array::from_fn(|i| i);
-    let v: f64 = x
-        .into_iter()
-        .map(|x| {
-            n[x] * ((((p * 4.0e-8) - 0.875).powf(0.5)).powi(i[x])
-                * ((t / 670.0) - 0.964).powi(j[x]))
-        })
-        .sum();
-    v.powi(4) * 0.0054
+    if cfg!(feature = "nightly") {
+        let (p_base, t_base): ([f64; 29], [f64; 29]) = (
+            std::array::from_fn(|x| (((p * 4.0e-8) - 0.875).powf(0.5)).powi(i[x])),
+            std::array::from_fn(|x| ((t / 670.0) - 0.964).powi(j[x])),
+        );
+
+        let n = Simd::<f64, 32>::load_or_default(&n);
+        let t_base = Simd::<f64, 32>::load_or_default(&t_base);
+        let p_base = Simd::<f64, 32>::load_or_default(&p_base);
+
+        0.0054 * ((n * p_base * t_base).reduce_sum()).powi(4)
+    } else {
+        let x: [usize; 29] = core::array::from_fn(|i| i);
+        let v: f64 = x
+            .into_iter()
+            .map(|x| {
+                n[x] * ((((p * 4.0e-8) - 0.875).powf(0.5)).powi(i[x])
+                    * ((t / 670.0) - 0.964).powi(j[x]))
+            })
+            .sum();
+        v.powi(4) * 0.0054
+    }
 }
 
 fn subregion_k(t: f64, p: f64) -> f64 {
@@ -718,12 +849,25 @@ fn subregion_k(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 34] = core::array::from_fn(|i| i);
-    let v: f64 = x
-        .into_iter()
-        .map(|x| n[x] * (((p * 4.0e-8) - 0.802).powi(i[x]) * ((t / 680.0) - 0.935).powi(j[x])))
-        .sum();
-    v * 0.0077
+    if cfg!(feature = "nightly") {
+        let (p_base, t_base): ([f64; 34], [f64; 34]) = (
+            std::array::from_fn(|x| ((p * 4.0e-8) - 0.802).powi(i[x])),
+            std::array::from_fn(|x| ((t / 680.0) - 0.935).powi(j[x])),
+        );
+
+        let n = Simd::<f64, 64>::load_or_default(&n);
+        let t_base = Simd::<f64, 64>::load_or_default(&t_base);
+        let p_base = Simd::<f64, 64>::load_or_default(&p_base);
+
+        0.0077 * (n * p_base * t_base).reduce_sum()
+    } else {
+        let x: [usize; 34] = core::array::from_fn(|i| i);
+        let v: f64 = x
+            .into_iter()
+            .map(|x| n[x] * (((p * 4.0e-8) - 0.802).powi(i[x]) * ((t / 680.0) - 0.935).powi(j[x])))
+            .sum();
+        v * 0.0077
+    }
 }
 
 fn subregion_l(t: f64, p: f64) -> f64 {
@@ -784,12 +928,25 @@ fn subregion_l(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 43] = core::array::from_fn(|i| i);
-    let v: f64 = x
-        .into_iter()
-        .map(|x| n[x] * (((p / 24.0e6) - 0.908).powi(i[x]) * ((t / 650.0) - 0.989).powi(j[x])))
-        .sum();
-    v.powi(4) * 0.0026
+    if cfg!(feature = "nightly") {
+        let (p_base, t_base): ([f64; 43], [f64; 43]) = (
+            std::array::from_fn(|x| ((p / 24.0e6) - 0.908).powi(i[x])),
+            std::array::from_fn(|x| ((t / 650.0) - 0.989).powi(j[x])),
+        );
+
+        let n = Simd::<f64, 64>::load_or_default(&n);
+        let t_base = Simd::<f64, 64>::load_or_default(&t_base);
+        let p_base = Simd::<f64, 64>::load_or_default(&p_base);
+
+        0.0026 * ((n * p_base * t_base).reduce_sum()).powi(4)
+    } else {
+        let x: [usize; 43] = core::array::from_fn(|i| i);
+        let v: f64 = x
+            .into_iter()
+            .map(|x| n[x] * (((p / 24.0e6) - 0.908).powi(i[x]) * ((t / 650.0) - 0.989).powi(j[x])))
+            .sum();
+        v.powi(4) * 0.0026
+    }
 }
 
 fn subregion_m(t: f64, p: f64) -> f64 {
@@ -847,14 +1004,28 @@ fn subregion_m(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 40] = core::array::from_fn(|i| i);
-    let v: f64 = x
-        .into_iter()
-        .map(|x| {
-            n[x] * (((p / 23.0e6) - 1.0).powi(i[x]) * (((t / 650.0) - 0.997).powf(0.25)).powi(j[x]))
-        })
-        .sum();
-    v * 0.0028
+    if cfg!(feature = "nightly") {
+        let (p_base, t_base): ([f64; 40], [f64; 40]) = (
+            std::array::from_fn(|x| ((p / 23.0e6) - 1.0).powi(i[x])),
+            std::array::from_fn(|x| (((t / 650.0) - 0.997).powf(0.25)).powi(j[x])),
+        );
+
+        let n = Simd::<f64, 64>::load_or_default(&n);
+        let t_base = Simd::<f64, 64>::load_or_default(&t_base);
+        let p_base = Simd::<f64, 64>::load_or_default(&p_base);
+
+        0.0028 * (n * p_base * t_base).reduce_sum()
+    } else {
+        let x: [usize; 40] = core::array::from_fn(|i| i);
+        let v: f64 = x
+            .into_iter()
+            .map(|x| {
+                n[x] * (((p / 23.0e6) - 1.0).powi(i[x])
+                    * (((t / 650.0) - 0.997).powf(0.25)).powi(j[x]))
+            })
+            .sum();
+        v * 0.0028
+    }
 }
 
 fn subregion_n(t: f64, p: f64) -> f64 {
@@ -911,12 +1082,25 @@ fn subregion_n(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 39] = core::array::from_fn(|i| i);
-    let v: f64 = x
-        .into_iter()
-        .map(|x| n[x] * (((p / 23.0e6) - 0.976).powi(i[x]) * ((t / 650.0) - 0.997).powi(j[x])))
-        .sum();
-    v.exp() * 0.0031
+    if cfg!(feature = "nightly") {
+        let (p_base, t_base): ([f64; 39], [f64; 39]) = (
+            std::array::from_fn(|x| ((p / 23.0e6) - 0.976).powi(i[x])),
+            std::array::from_fn(|x| ((t / 650.0) - 0.997).powi(j[x])),
+        );
+
+        let n = Simd::<f64, 64>::load_or_default(&n);
+        let t_base = Simd::<f64, 64>::load_or_default(&t_base);
+        let p_base = Simd::<f64, 64>::load_or_default(&p_base);
+
+        0.0031 * ((n * p_base * t_base).reduce_sum()).exp()
+    } else {
+        let x: [usize; 39] = core::array::from_fn(|i| i);
+        let v: f64 = x
+            .into_iter()
+            .map(|x| n[x] * (((p / 23.0e6) - 0.976).powi(i[x]) * ((t / 650.0) - 0.997).powi(j[x])))
+            .sum();
+        v.exp() * 0.0031
+    }
 }
 
 fn subregion_o(t: f64, p: f64) -> f64 {
@@ -957,15 +1141,28 @@ fn subregion_o(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 24] = core::array::from_fn(|i| i);
-    let v: f64 = x
-        .into_iter()
-        .map(|x| {
-            n[x] * ((((p / 23.0e6) - 0.974).powf(0.5)).powi(i[x])
-                * ((t / 650.0) - 0.996).powi(j[x]))
-        })
-        .sum();
-    v * 0.0034
+    if cfg!(feature = "nightly") {
+        let (p_base, t_base): ([f64; 24], [f64; 24]) = (
+            std::array::from_fn(|x| (((p / 23.0e6) - 0.974).powf(0.5)).powi(i[x])),
+            std::array::from_fn(|x| ((t / 650.0) - 0.996).powi(j[x])),
+        );
+
+        let n = Simd::<f64, 32>::load_or_default(&n);
+        let t_base = Simd::<f64, 32>::load_or_default(&t_base);
+        let p_base = Simd::<f64, 32>::load_or_default(&p_base);
+
+        0.0034 * (n * p_base * t_base).reduce_sum()
+    } else {
+        let x: [usize; 24] = core::array::from_fn(|i| i);
+        let v: f64 = x
+            .into_iter()
+            .map(|x| {
+                n[x] * ((((p / 23.0e6) - 0.974).powf(0.5)).powi(i[x])
+                    * ((t / 650.0) - 0.996).powi(j[x]))
+            })
+            .sum();
+        v * 0.0034
+    }
 }
 
 fn subregion_p(t: f64, p: f64) -> f64 {
@@ -1010,15 +1207,28 @@ fn subregion_p(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 27] = core::array::from_fn(|i| i);
-    let v: f64 = x
-        .into_iter()
-        .map(|x| {
-            n[x] * ((((p / 23.0e6) - 0.972).powf(0.5)).powi(i[x])
-                * ((t / 650.0) - 0.997).powi(j[x]))
-        })
-        .sum();
-    v * 0.0041
+    if cfg!(feature = "nightly") {
+        let (p_base, t_base): ([f64; 27], [f64; 27]) = (
+            std::array::from_fn(|x| (((p / 23.0e6) - 0.972).powf(0.5)).powi(i[x])),
+            std::array::from_fn(|x| ((t / 650.0) - 0.997).powi(j[x])),
+        );
+
+        let n = Simd::<f64, 32>::load_or_default(&n);
+        let t_base = Simd::<f64, 32>::load_or_default(&t_base);
+        let p_base = Simd::<f64, 32>::load_or_default(&p_base);
+
+        0.0041 * (n * p_base * t_base).reduce_sum()
+    } else {
+        let x: [usize; 27] = core::array::from_fn(|i| i);
+        let v: f64 = x
+            .into_iter()
+            .map(|x| {
+                n[x] * ((((p / 23.0e6) - 0.972).powf(0.5)).powi(i[x])
+                    * ((t / 650.0) - 0.997).powi(j[x]))
+            })
+            .sum();
+        v * 0.0041
+    }
 }
 
 fn subregion_q(t: f64, p: f64) -> f64 {
@@ -1059,12 +1269,25 @@ fn subregion_q(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 24] = core::array::from_fn(|i| i);
-    let v: f64 = x
-        .into_iter()
-        .map(|x| n[x] * (((p / 23e6) - 0.848).powi(i[x]) * ((t / 650.0) - 0.983).powi(j[x])))
-        .sum();
-    v.powi(4) * 0.0022
+    if cfg!(feature = "nightly") {
+        let (p_base, t_base): ([f64; 24], [f64; 24]) = (
+            std::array::from_fn(|x| ((p / 23e6) - 0.848).powi(i[x])),
+            std::array::from_fn(|x| ((t / 650.0) - 0.983).powi(j[x])),
+        );
+
+        let n = Simd::<f64, 32>::load_or_default(&n);
+        let t_base = Simd::<f64, 32>::load_or_default(&t_base);
+        let p_base = Simd::<f64, 32>::load_or_default(&p_base);
+
+        0.0022 * ((n * p_base * t_base).reduce_sum()).powi(4)
+    } else {
+        let x: [usize; 24] = core::array::from_fn(|i| i);
+        let v: f64 = x
+            .into_iter()
+            .map(|x| n[x] * (((p / 23e6) - 0.848).powi(i[x]) * ((t / 650.0) - 0.983).powi(j[x])))
+            .sum();
+        v.powi(4) * 0.0022
+    }
 }
 
 fn subregion_r(t: f64, p: f64) -> f64 {
@@ -1109,12 +1332,25 @@ fn subregion_r(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 27] = core::array::from_fn(|i| i);
-    let v: f64 = x
-        .into_iter()
-        .map(|x| n[x] * (((p / 23e6) - 0.874).powi(i[x]) * ((t / 650.0) - 0.982).powi(j[x])))
-        .sum();
-    v * 0.0054
+    if cfg!(feature = "nightly") {
+        let (p_base, t_base): ([f64; 27], [f64; 27]) = (
+            std::array::from_fn(|x| ((p / 23e6) - 0.874).powi(i[x])),
+            std::array::from_fn(|x| ((t / 650.0) - 0.982).powi(j[x])),
+        );
+
+        let n = Simd::<f64, 32>::load_or_default(&n);
+        let t_base = Simd::<f64, 32>::load_or_default(&t_base);
+        let p_base = Simd::<f64, 32>::load_or_default(&p_base);
+
+        0.0054 * (n * p_base * t_base).reduce_sum()
+    } else {
+        let x: [usize; 27] = core::array::from_fn(|i| i);
+        let v: f64 = x
+            .into_iter()
+            .map(|x| n[x] * (((p / 23e6) - 0.874).powi(i[x]) * ((t / 650.0) - 0.982).powi(j[x])))
+            .sum();
+        v * 0.0054
+    }
 }
 
 fn subregion_s(t: f64, p: f64) -> f64 {
@@ -1161,12 +1397,25 @@ fn subregion_s(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 29] = core::array::from_fn(|i| i);
-    let v: f64 = x
-        .into_iter()
-        .map(|x| n[x] * (((p / 21e6) - 0.886).powi(i[x]) * ((t / 640.0) - 0.990).powi(j[x])))
-        .sum();
-    v.powi(4) * 0.0022
+    if cfg!(feature = "nightly") {
+        let (p_base, t_base): ([f64; 29], [f64; 29]) = (
+            std::array::from_fn(|x| ((p / 21e6) - 0.886).powi(i[x])),
+            std::array::from_fn(|x| ((t / 640.0) - 0.990).powi(j[x])),
+        );
+
+        let n = Simd::<f64, 32>::load_or_default(&n);
+        let t_base = Simd::<f64, 32>::load_or_default(&t_base);
+        let p_base = Simd::<f64, 32>::load_or_default(&p_base);
+
+        0.0022 * ((n * p_base * t_base).reduce_sum()).powi(4)
+    } else {
+        let x: [usize; 29] = core::array::from_fn(|i| i);
+        let v: f64 = x
+            .into_iter()
+            .map(|x| n[x] * (((p / 21e6) - 0.886).powi(i[x]) * ((t / 640.0) - 0.990).powi(j[x])))
+            .sum();
+        v.powi(4) * 0.0022
+    }
 }
 
 fn subregion_t(t: f64, p: f64) -> f64 {
@@ -1217,12 +1466,25 @@ fn subregion_t(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 33] = core::array::from_fn(|i| i);
-    let v: f64 = x
-        .into_iter()
-        .map(|x| n[x] * (((p / 20e6) - 0.803).powi(i[x]) * ((t / 650.0) - 1.020).powi(j[x])))
-        .sum();
-    v * 0.0088
+    if cfg!(feature = "nightly") {
+        let (p_base, t_base): ([f64; 33], [f64; 33]) = (
+            std::array::from_fn(|x| ((p / 20e6) - 0.803).powi(i[x])),
+            std::array::from_fn(|x| ((t / 650.0) - 1.020).powi(j[x])),
+        );
+
+        let n = Simd::<f64, 64>::load_or_default(&n);
+        let t_base = Simd::<f64, 64>::load_or_default(&t_base);
+        let p_base = Simd::<f64, 64>::load_or_default(&p_base);
+
+        0.0088 * (n * p_base * t_base).reduce_sum()
+    } else {
+        let x: [usize; 33] = core::array::from_fn(|i| i);
+        let v: f64 = x
+            .into_iter()
+            .map(|x| n[x] * (((p / 20e6) - 0.803).powi(i[x]) * ((t / 650.0) - 1.020).powi(j[x])))
+            .sum();
+        v * 0.0088
+    }
 }
 
 fn subregion_u(t: f64, p: f64) -> f64 {
@@ -1278,12 +1540,25 @@ fn subregion_u(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 38] = core::array::from_fn(|i| i);
-    let v: f64 = x
-        .into_iter()
-        .map(|x| n[x] * (((p / 23e6) - 0.902).powi(i[x]) * ((t / 650.0) - 0.988).powi(j[x])))
-        .sum();
-    v * 0.0026
+    if cfg!(feature = "nightly") {
+        let (p_base, t_base): ([f64; 38], [f64; 38]) = (
+            std::array::from_fn(|x| ((p / 23e6) - 0.902).powi(i[x])),
+            std::array::from_fn(|x| ((t / 650.0) - 0.988).powi(j[x])),
+        );
+
+        let n = Simd::<f64, 64>::load_or_default(&n);
+        let t_base = Simd::<f64, 64>::load_or_default(&t_base);
+        let p_base = Simd::<f64, 64>::load_or_default(&p_base);
+
+        0.0026 * (n * p_base * t_base).reduce_sum()
+    } else {
+        let x: [usize; 38] = core::array::from_fn(|i| i);
+        let v: f64 = x
+            .into_iter()
+            .map(|x| n[x] * (((p / 23e6) - 0.902).powi(i[x]) * ((t / 650.0) - 0.988).powi(j[x])))
+            .sum();
+        v * 0.0026
+    }
 }
 
 fn subregion_v(t: f64, p: f64) -> f64 {
@@ -1340,12 +1615,25 @@ fn subregion_v(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 39] = core::array::from_fn(|i| i);
-    let v: f64 = x
-        .into_iter()
-        .map(|x| n[x] * (((p / 23e6) - 0.960).powi(i[x]) * ((t / 650.0) - 0.995).powi(j[x])))
-        .sum();
-    v * 0.0031
+    if cfg!(feature = "nightly") {
+        let (p_base, t_base): ([f64; 39], [f64; 39]) = (
+            std::array::from_fn(|x| ((p / 23e6) - 0.960).powi(i[x])),
+            std::array::from_fn(|x| ((t / 650.0) - 0.995).powi(j[x])),
+        );
+
+        let n = Simd::<f64, 64>::load_or_default(&n);
+        let t_base = Simd::<f64, 64>::load_or_default(&t_base);
+        let p_base = Simd::<f64, 64>::load_or_default(&p_base);
+
+        0.0031 * (n * p_base * t_base).reduce_sum()
+    } else {
+        let x: [usize; 39] = core::array::from_fn(|i| i);
+        let v: f64 = x
+            .into_iter()
+            .map(|x| n[x] * (((p / 23e6) - 0.960).powi(i[x]) * ((t / 650.0) - 0.995).powi(j[x])))
+            .sum();
+        v * 0.0031
+    }
 }
 
 fn subregion_w(t: f64, p: f64) -> f64 {
@@ -1398,12 +1686,25 @@ fn subregion_w(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 35] = core::array::from_fn(|i| i);
-    let v: f64 = x
-        .into_iter()
-        .map(|x| n[x] * (((p / 23e6) - 0.959).powi(i[x]) * ((t / 650.0) - 0.995).powi(j[x])))
-        .sum();
-    v.powi(4) * 0.0039
+    if cfg!(feature = "nightly") {
+        let (p_base, t_base): ([f64; 35], [f64; 35]) = (
+            std::array::from_fn(|x| ((p / 23e6) - 0.959).powi(i[x])),
+            std::array::from_fn(|x| ((t / 650.0) - 0.995).powi(j[x])),
+        );
+
+        let n = Simd::<f64, 64>::load_or_default(&n);
+        let t_base = Simd::<f64, 64>::load_or_default(&t_base);
+        let p_base = Simd::<f64, 64>::load_or_default(&p_base);
+
+        0.0039 * ((n * p_base * t_base).reduce_sum()).powi(4)
+    } else {
+        let x: [usize; 35] = core::array::from_fn(|i| i);
+        let v: f64 = x
+            .into_iter()
+            .map(|x| n[x] * (((p / 23e6) - 0.959).powi(i[x]) * ((t / 650.0) - 0.995).powi(j[x])))
+            .sum();
+        v.powi(4) * 0.0039
+    }
 }
 
 fn subregion_x(t: f64, p: f64) -> f64 {
@@ -1457,12 +1758,25 @@ fn subregion_x(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 36] = core::array::from_fn(|i| i);
-    let v: f64 = x
-        .into_iter()
-        .map(|x| n[x] * (((p / 23e6) - 0.910).powi(i[x]) * ((t / 650.0) - 0.988).powi(j[x])))
-        .sum();
-    v * 0.0049
+    if cfg!(feature = "nightly") {
+        let (p_base, t_base): ([f64; 36], [f64; 36]) = (
+            std::array::from_fn(|x| ((p / 23e6) - 0.910).powi(i[x])),
+            std::array::from_fn(|x| ((t / 650.0) - 0.988).powi(j[x])),
+        );
+
+        let n = Simd::<f64, 64>::load_or_default(&n);
+        let t_base = Simd::<f64, 64>::load_or_default(&t_base);
+        let p_base = Simd::<f64, 64>::load_or_default(&p_base);
+
+        0.0049 * (n * p_base * t_base).reduce_sum()
+    } else {
+        let x: [usize; 36] = core::array::from_fn(|i| i);
+        let v: f64 = x
+            .into_iter()
+            .map(|x| n[x] * (((p / 23e6) - 0.910).powi(i[x]) * ((t / 650.0) - 0.988).powi(j[x])))
+            .sum();
+        v * 0.0049
+    }
 }
 
 fn subregion_y(t: f64, p: f64) -> f64 {
@@ -1496,12 +1810,25 @@ fn subregion_y(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 20] = core::array::from_fn(|i| i);
-    let v: f64 = x
-        .into_iter()
-        .map(|x| n[x] * (((p / 22e6) - 0.996).powi(i[x]) * ((t / 650.0) - 0.994).powi(j[x])))
-        .sum();
-    v.powi(4) * 0.0031
+    if cfg!(feature = "nightly") {
+        let (p_base, t_base): ([f64; 20], [f64; 20]) = (
+            std::array::from_fn(|x| ((p / 22e6) - 0.996).powi(i[x])),
+            std::array::from_fn(|x| ((t / 650.0) - 0.994).powi(j[x])),
+        );
+
+        let n = Simd::<f64, 32>::load_or_default(&n);
+        let t_base = Simd::<f64, 32>::load_or_default(&t_base);
+        let p_base = Simd::<f64, 32>::load_or_default(&p_base);
+
+        0.0031 * ((n * p_base * t_base).reduce_sum()).powi(4)
+    } else {
+        let x: [usize; 20] = core::array::from_fn(|i| i);
+        let v: f64 = x
+            .into_iter()
+            .map(|x| n[x] * (((p / 22e6) - 0.996).powi(i[x]) * ((t / 650.0) - 0.994).powi(j[x])))
+            .sum();
+        v.powi(4) * 0.0031
+    }
 }
 
 fn subregion_z(t: f64, p: f64) -> f64 {
@@ -1540,133 +1867,310 @@ fn subregion_z(t: f64, p: f64) -> f64 {
     ];
 
     // Calculate v
-    let x: [usize; 23] = core::array::from_fn(|i| i);
-    let v: f64 = x
-        .into_iter()
-        .map(|x| n[x] * (((p / 22e6) - 0.993).powi(i[x]) * ((t / 650.0) - 0.994).powi(j[x])))
-        .sum();
-    v.powi(4) * 0.0038
+    if cfg!(feature = "nightly") {
+        let (p_base, t_base): ([f64; 23], [f64; 23]) = (
+            std::array::from_fn(|x| ((p / 22e6) - 0.993).powi(i[x])),
+            std::array::from_fn(|x| ((t / 650.0) - 0.994).powi(j[x])),
+        );
+
+        let n = Simd::<f64, 32>::load_or_default(&n);
+        let t_base = Simd::<f64, 32>::load_or_default(&t_base);
+        let p_base = Simd::<f64, 32>::load_or_default(&p_base);
+
+        0.0038 * ((n * p_base * t_base).reduce_sum()).powi(4)
+    } else {
+        let x: [usize; 23] = core::array::from_fn(|i| i);
+        let v: f64 = x
+            .into_iter()
+            .map(|x| n[x] * (((p / 22e6) - 0.993).powi(i[x]) * ((t / 650.0) - 0.994).powi(j[x])))
+            .sum();
+        v.powi(4) * 0.0038
+    }
 }
 
 // Returns the subregion that corresponds
 // to the state of water given t and p
 fn subregion(t: f64, p: f64) -> Region3 {
     // Create coefficient Arrays
-    let coefficients_ab: [f64; 5] = [
-        0.154793642129415e4,
-        -0.187661219490113e3,
-        0.213144632222113e2,
-        -0.191887498864292e4,
-        0.918419702359447e3,
-    ];
+    let (t_ab, t_cd, t_ef, t_gh, t_ij, t_jk, t_mn, t_op, t_qu, t_rx, t_uv, t_wx) =
+        if cfg!(feature = "nightly") {
+            let coefficients_ab: Simd<f64, 8> = [
+                0.154793642129415e4,
+                -0.187661219490113e3,
+                0.213144632222113e2,
+                -0.191887498864292e4,
+                0.918419702359447e3,
+                0.0,
+                0.0,
+                0.0,
+            ]
+            .into();
 
-    let coefficients_cd: [f64; 4] = [
-        0.585276966696349e3,
-        0.278233532206915e1,
-        -0.127283549295878e-1,
-        0.159090746562729e-3,
-    ];
+            let coefficients_cd: Simd<f64, 8> = [
+                0.585276966696349e3,
+                0.278233532206915e1,
+                -0.127283549295878e-1,
+                0.159090746562729e-3,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+            ]
+            .into();
 
-    let coefficients_gh: [f64; 5] = [
-        -0.249284240900418e5,
-        0.428143584791546e4,
-        -0.269029173140130e3,
-        0.751608051114157e1,
-        -0.787105249910383e-1,
-    ];
+            let coefficients_gh: Simd<f64, 8> = [
+                -0.249284240900418e5,
+                0.428143584791546e4,
+                -0.269029173140130e3,
+                0.751608051114157e1,
+                -0.787105249910383e-1,
+                0.0,
+                0.0,
+                0.0,
+            ]
+            .into();
 
-    let coefficients_ij: [f64; 5] = [
-        0.584814781649163e3,
-        -0.616179320924617,
-        0.260763050899562,
-        -0.587071076864459e-2,
-        0.515308185433082e-4,
-    ];
+            let coefficients_ij: Simd<f64, 8> = [
+                0.584814781649163e3,
+                -0.616179320924617,
+                0.260763050899562,
+                -0.587071076864459e-2,
+                0.515308185433082e-4,
+                0.0,
+                0.0,
+                0.0,
+            ]
+            .into();
 
-    let coefficients_jk: [f64; 5] = [
-        0.617229772068439e3,
-        -0.770600270141675e1,
-        0.697072596851896,
-        -0.157391839848015e-1,
-        0.137897492684194e-3,
-    ];
+            let coefficients_jk: Simd<f64, 8> = [
+                0.617229772068439e3,
+                -0.770600270141675e1,
+                0.697072596851896,
+                -0.157391839848015e-1,
+                0.137897492684194e-3,
+                0.0,
+                0.0,
+                0.0,
+            ]
+            .into();
 
-    let coefficients_mn: [f64; 4] = [
-        0.535339483742384e3,
-        0.761978122720128e1,
-        -0.158365725441648,
-        0.192871054508108e-2,
-    ];
+            let coefficients_mn: Simd<f64, 8> = [
+                0.535339483742384e3,
+                0.761978122720128e1,
+                -0.158365725441648,
+                0.192871054508108e-2,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+            ]
+            .into();
 
-    let coefficients_op: [f64; 5] = [
-        0.969461372400213e3,
-        -0.332500170441278e3,
-        0.642859598466067e2,
-        0.773845935768222e3,
-        -0.152313732937084e4,
-    ];
+            let coefficients_op: Simd<f64, 8> = [
+                0.969461372400213e3,
+                -0.332500170441278e3,
+                0.642859598466067e2,
+                0.773845935768222e3,
+                -0.152313732937084e4,
+                0.0,
+                0.0,
+                0.0,
+            ]
+            .into();
 
-    let coefficients_qu: [f64; 4] = [
-        0.565603648239126e3,
-        0.529062258221222e1,
-        -0.102020639611016,
-        0.122240301070145e-2,
-    ];
+            let coefficients_qu: Simd<f64, 8> = [
+                0.565603648239126e3,
+                0.529062258221222e1,
+                -0.102020639611016,
+                0.122240301070145e-2,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+            ]
+            .into();
 
-    let coefficients_uv: [f64; 4] = [
-        0.528199646263062e3,
-        0.890579602135307e1,
-        -0.222814134903755,
-        0.286791682263697e-2,
-    ];
+            let coefficients_uv: Simd<f64, 8> = [
+                0.528199646263062e3,
+                0.890579602135307e1,
+                -0.222814134903755,
+                0.286791682263697e-2,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+            ]
+            .into();
 
-    let coefficients_wx: [f64; 5] = [
-        0.728052609145380e1,
-        0.973505869861952e2,
-        0.147370491183191e2,
-        0.329196213998375e3,
-        0.873371668682417e3,
-    ];
+            let coefficients_wx: Simd<f64, 8> = [
+                0.728052609145380e1,
+                0.973505869861952e2,
+                0.147370491183191e2,
+                0.329196213998375e3,
+                0.873371668682417e3,
+                0.0,
+                0.0,
+                0.0,
+            ]
+            .into();
 
-    let coefficients_rx: [f64; 4] = [
-        0.584561202520006e3,
-        -0.102961025163669e1,
-        0.243293362700452,
-        -0.294905044740799e-2,
-    ];
+            let coefficients_rx: Simd<f64, 8> = [
+                0.584561202520006e3,
+                -0.102961025163669e1,
+                0.243293362700452,
+                -0.294905044740799e-2,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+            ]
+            .into();
 
-    let ii: [i32; 5] = [0, 1, 2, -1, -2];
+            let ii: [i32; 5] = [0, 1, 2, -1, -2];
+            let p_ln = (p * 1e-6).ln();
+            let (p_ln_base, p_base): ([f64; 5], [f64; 5]) = (
+                std::array::from_fn(|x| p_ln.powi(ii[x])),
+                std::array::from_fn(|x| (p * 1e-6).powi(x as i32)),
+            );
 
-    // Create variables for later use
-    let mut t_ab: f64 = 0.0;
-    let mut t_cd: f64 = 0.0;
-    let t_ef: f64 = 3.727888004 * ((p * 1e-6) - 22.064) + 647.096;
-    let mut t_gh: f64 = 0.0;
-    let mut t_ij: f64 = 0.0;
-    let mut t_jk: f64 = 0.0;
-    let mut t_mn: f64 = 0.0;
-    let mut t_op: f64 = 0.0;
-    let mut t_qu: f64 = 0.0;
-    let mut t_uv: f64 = 0.0;
-    let mut t_wx: f64 = 0.0;
-    let mut t_rx: f64 = 0.0;
+            let p_ln_base = Simd::<f64, 8>::load_or_default(&p_ln_base);
+            let p_base = Simd::<f64, 8>::load_or_default(&p_base);
 
-    // Calculate Boundaries
-    for x in 0..=4 {
-        if x <= 3 {
-            t_cd += coefficients_cd[x] * (p * 1e-6).powi(x as i32);
-            t_mn += coefficients_mn[x] * (p * 1e-6).powi(x as i32);
-            t_qu += coefficients_qu[x] * (p * 1e-6).powi(x as i32);
-            t_rx += coefficients_rx[x] * (p * 1e-6).powi(x as i32);
-            t_uv += coefficients_uv[x] * (p * 1e-6).powi(x as i32)
-        }
-        t_ab += coefficients_ab[x] * ((p * 1e-6).ln()).powi(ii[x]);
-        t_gh += coefficients_gh[x] * (p * 1e-6).powi(x as i32);
-        t_ij += coefficients_ij[x] * (p * 1e-6).powi(x as i32);
-        t_jk += coefficients_jk[x] * (p * 1e-6).powi(x as i32);
-        t_op += coefficients_op[x] * ((p * 1e-6).ln()).powi(ii[x]);
-        t_wx += coefficients_wx[x] * ((p * 1e-6).ln()).powi(ii[x]);
-    }
+            let t_ab = (coefficients_ab * p_ln_base).reduce_sum();
+            let t_cd = (coefficients_cd * p_base).reduce_sum();
+            let t_ef = 3.727888004 * (p * 1e-6 - 22.064) + 647.096;
+            let t_gh = (coefficients_gh * p_base).reduce_sum();
+            let t_ij = (coefficients_ij * p_base).reduce_sum();
+            let t_jk = (coefficients_jk * p_base).reduce_sum();
+            let t_mn = (coefficients_mn * p_base).reduce_sum();
+            let t_op = (coefficients_op * p_ln_base).reduce_sum();
+            let t_qu = (coefficients_qu * p_base).reduce_sum();
+            let t_rx = (coefficients_rx * p_base).reduce_sum();
+            let t_uv = (coefficients_uv * p_base).reduce_sum();
+            let t_wx = (coefficients_wx * p_ln_base).reduce_sum();
+            (
+                t_ab, t_cd, t_ef, t_gh, t_ij, t_jk, t_mn, t_op, t_qu, t_rx, t_uv, t_wx,
+            )
+        } else {
+            let coefficients_ab: [f64; 5] = [
+                0.154793642129415e4,
+                -0.187661219490113e3,
+                0.213144632222113e2,
+                -0.191887498864292e4,
+                0.918419702359447e3,
+            ];
+
+            let coefficients_cd: [f64; 4] = [
+                0.585276966696349e3,
+                0.278233532206915e1,
+                -0.127283549295878e-1,
+                0.159090746562729e-3,
+            ];
+
+            let coefficients_gh: [f64; 5] = [
+                -0.249284240900418e5,
+                0.428143584791546e4,
+                -0.269029173140130e3,
+                0.751608051114157e1,
+                -0.787105249910383e-1,
+            ];
+
+            let coefficients_ij: [f64; 5] = [
+                0.584814781649163e3,
+                -0.616179320924617,
+                0.260763050899562,
+                -0.587071076864459e-2,
+                0.515308185433082e-4,
+            ];
+
+            let coefficients_jk: [f64; 5] = [
+                0.617229772068439e3,
+                -0.770600270141675e1,
+                0.697072596851896,
+                -0.157391839848015e-1,
+                0.137897492684194e-3,
+            ];
+
+            let coefficients_mn: [f64; 4] = [
+                0.535339483742384e3,
+                0.761978122720128e1,
+                -0.158365725441648,
+                0.192871054508108e-2,
+            ];
+
+            let coefficients_op: [f64; 5] = [
+                0.969461372400213e3,
+                -0.332500170441278e3,
+                0.642859598466067e2,
+                0.773845935768222e3,
+                -0.152313732937084e4,
+            ];
+
+            let coefficients_qu: [f64; 4] = [
+                0.565603648239126e3,
+                0.529062258221222e1,
+                -0.102020639611016,
+                0.122240301070145e-2,
+            ];
+
+            let coefficients_uv: [f64; 4] = [
+                0.528199646263062e3,
+                0.890579602135307e1,
+                -0.222814134903755,
+                0.286791682263697e-2,
+            ];
+
+            let coefficients_wx: [f64; 5] = [
+                0.728052609145380e1,
+                0.973505869861952e2,
+                0.147370491183191e2,
+                0.329196213998375e3,
+                0.873371668682417e3,
+            ];
+
+            let coefficients_rx: [f64; 4] = [
+                0.584561202520006e3,
+                -0.102961025163669e1,
+                0.243293362700452,
+                -0.294905044740799e-2,
+            ];
+
+            let ii: [i32; 5] = [0, 1, 2, -1, -2];
+
+            // Create variables for later use
+            let mut t_ab: f64 = 0.0;
+            let mut t_cd: f64 = 0.0;
+            let t_ef: f64 = 3.727888004 * ((p * 1e-6) - 22.064) + 647.096;
+            let mut t_gh: f64 = 0.0;
+            let mut t_ij: f64 = 0.0;
+            let mut t_jk: f64 = 0.0;
+            let mut t_mn: f64 = 0.0;
+            let mut t_op: f64 = 0.0;
+            let mut t_qu: f64 = 0.0;
+            let mut t_uv: f64 = 0.0;
+            let mut t_wx: f64 = 0.0;
+            let mut t_rx: f64 = 0.0;
+
+            // Calculate Boundaries
+            for x in 0..=4 {
+                if x <= 3 {
+                    t_cd += coefficients_cd[x] * (p * 1e-6).powi(x as i32);
+                    t_mn += coefficients_mn[x] * (p * 1e-6).powi(x as i32);
+                    t_qu += coefficients_qu[x] * (p * 1e-6).powi(x as i32);
+                    t_rx += coefficients_rx[x] * (p * 1e-6).powi(x as i32);
+                    t_uv += coefficients_uv[x] * (p * 1e-6).powi(x as i32)
+                }
+                t_ab += coefficients_ab[x] * ((p * 1e-6).ln()).powi(ii[x]);
+                t_gh += coefficients_gh[x] * (p * 1e-6).powi(x as i32);
+                t_ij += coefficients_ij[x] * (p * 1e-6).powi(x as i32);
+                t_jk += coefficients_jk[x] * (p * 1e-6).powi(x as i32);
+                t_op += coefficients_op[x] * ((p * 1e-6).ln()).powi(ii[x]);
+                t_wx += coefficients_wx[x] * ((p * 1e-6).ln()).powi(ii[x]);
+            }
+            (
+                t_ab, t_cd, t_ef, t_gh, t_ij, t_jk, t_mn, t_op, t_qu, t_rx, t_uv, t_wx,
+            )
+        };
 
     // Calculate the Density
     match (t, p) {
@@ -1785,14 +2289,27 @@ fn tau_3(t: f64) -> f64 {
 fn phi_3(rho: f64, t: f64) -> f64 {
     let tau: f64 = tau_3(t);
     let delta: f64 = delta_3(rho);
-    let mut sum: f64 = 0.0_f64;
-    for x in 1..REGION_3_COEFFS_II.len() {
-        let ii = REGION_3_COEFFS_II[x];
-        let ji = REGION_3_COEFFS_JI[x];
-        let ni = REGION_3_COEFFS_NI[x];
-        sum += ni * delta.powi(ii) * tau.powi(ji);
+    if cfg!(feature = "nightly") {
+        let (delta, tau): ([f64; 39], [f64; 39]) = (
+            std::array::from_fn(|x| delta.powi(REGION_3_COEFFS_II[x + 1])),
+            std::array::from_fn(|x| tau.powi(REGION_3_COEFFS_JI[x + 1])),
+        );
+
+        let ni = Simd::<f64, 64>::load_or_default(&REGION_3_COEFFS_NI[1..40]);
+        let delta = Simd::<f64, 64>::load_or_default(&delta);
+        let tau = Simd::<f64, 64>::load_or_default(&tau);
+
+        (ni * delta * tau).reduce_sum() + REGION_3_COEFFS_NI[0] * delta_3(rho).ln()
+    } else {
+        let mut sum: f64 = 0.0_f64;
+        for x in 1..REGION_3_COEFFS_II.len() {
+            let ii = REGION_3_COEFFS_II[x];
+            let ji = REGION_3_COEFFS_JI[x];
+            let ni = REGION_3_COEFFS_NI[x];
+            sum += ni * delta.powi(ii) * tau.powi(ji);
+        }
+        sum + REGION_3_COEFFS_NI[0] * delta_3(rho).ln()
     }
-    sum + REGION_3_COEFFS_NI[0] * delta_3(rho).ln()
 }
 
 /// Returns the region-3 phi_delta
@@ -1800,15 +2317,29 @@ fn phi_3(rho: f64, t: f64) -> f64 {
 /// Pressure is assumed to be in Pa
 fn phi_delta_3(rho: f64, t: f64) -> f64 {
     let tau: f64 = tau_3(t);
-    let delta: f64 = delta_3(rho);
-    let mut sum: f64 = 0.0_f64;
-    for x in 1..REGION_3_COEFFS_II.len() {
-        let ii = REGION_3_COEFFS_II[x];
-        let ji = REGION_3_COEFFS_JI[x];
-        let ni = REGION_3_COEFFS_NI[x];
-        sum += ni * delta.powi(ii - 1) * ii as f64 * tau.powi(ji);
+    let delta_3: f64 = delta_3(rho);
+    if cfg!(feature = "nightly") {
+        let (delta, tau): ([f64; 39], [f64; 39]) = (
+            std::array::from_fn(|x| delta_3.powi(REGION_3_COEFFS_II[x + 1] - 1)),
+            std::array::from_fn(|x| tau.powi(REGION_3_COEFFS_JI[x + 1])),
+        );
+
+        let ni = Simd::<f64, 64>::load_or_default(&REGION_3_COEFFS_NI[1..40]);
+        let ii = (Simd::<i32, 64>::load_or_default(&REGION_3_COEFFS_II[1..40])).cast::<f64>();
+        let delta = Simd::<f64, 64>::load_or_default(&delta);
+        let tau = Simd::<f64, 64>::load_or_default(&tau);
+
+        (ni * ii * delta * tau).reduce_sum() + REGION_3_COEFFS_NI[0] / delta_3
+    } else {
+        let mut sum: f64 = 0.0_f64;
+        for x in 1..REGION_3_COEFFS_II.len() {
+            let ii = REGION_3_COEFFS_II[x];
+            let ji = REGION_3_COEFFS_JI[x];
+            let ni = REGION_3_COEFFS_NI[x];
+            sum += ni * delta_3.powi(ii - 1) * ii as f64 * tau.powi(ji);
+        }
+        sum + REGION_3_COEFFS_NI[0] / delta_3
     }
-    sum + REGION_3_COEFFS_NI[0] / delta
 }
 
 /// Returns the region-3 phi_delta_delta
@@ -1816,15 +2347,30 @@ fn phi_delta_3(rho: f64, t: f64) -> f64 {
 /// Pressure is assumed to be in Pa
 fn phi_delta_delta_3(rho: f64, t: f64) -> f64 {
     let tau: f64 = tau_3(t);
-    let delta: f64 = delta_3(rho);
-    let mut sum: f64 = 0.0_f64;
-    for x in 1..REGION_3_COEFFS_II.len() {
-        let ii = REGION_3_COEFFS_II[x];
-        let ji = REGION_3_COEFFS_JI[x];
-        let ni = REGION_3_COEFFS_NI[x];
-        sum += ni * delta.powi(ii - 2) * (ii * (ii - 1)) as f64 * tau.powi(ji);
+    let delta_3: f64 = delta_3(rho);
+    if cfg!(feature = "nightly") {
+        let (delta, tau): ([f64; 39], [f64; 39]) = (
+            std::array::from_fn(|x| delta_3.powi(REGION_3_COEFFS_II[x + 1] - 2)),
+            std::array::from_fn(|x| tau.powi(REGION_3_COEFFS_JI[x + 1])),
+        );
+
+        let ni = Simd::<f64, 64>::load_or_default(&REGION_3_COEFFS_NI[1..40]);
+        let ii = (Simd::<i32, 64>::load_or_default(&REGION_3_COEFFS_II[1..40])).cast::<f64>();
+        let delta = Simd::<f64, 64>::load_or_default(&delta);
+        let tau = Simd::<f64, 64>::load_or_default(&tau);
+
+        (ni * ii * (ii - f64x64::splat(1.0)) * delta * tau).reduce_sum()
+            - REGION_3_COEFFS_NI[0] / delta_3.powi(2)
+    } else {
+        let mut sum: f64 = 0.0_f64;
+        for x in 1..REGION_3_COEFFS_II.len() {
+            let ii = REGION_3_COEFFS_II[x];
+            let ji = REGION_3_COEFFS_JI[x];
+            let ni = REGION_3_COEFFS_NI[x];
+            sum += ni * delta_3.powi(ii - 2) * (ii * (ii - 1)) as f64 * tau.powi(ji);
+        }
+        sum - REGION_3_COEFFS_NI[0] / delta_3.powi(2)
     }
-    sum - REGION_3_COEFFS_NI[0] / delta.powi(2)
 }
 
 /// Returns the region-3 phi_tau
@@ -1832,15 +2378,29 @@ fn phi_delta_delta_3(rho: f64, t: f64) -> f64 {
 /// Pressure is assumed to be in Pa
 fn phi_tau_3(rho: f64, t: f64) -> f64 {
     let tau: f64 = tau_3(t);
-    let delta: f64 = delta_3(rho);
-    let mut sum: f64 = 0.0_f64;
-    for x in 1..REGION_3_COEFFS_II.len() {
-        let ii = REGION_3_COEFFS_II[x];
-        let ji = REGION_3_COEFFS_JI[x];
-        let ni = REGION_3_COEFFS_NI[x];
-        sum += ni * delta.powi(ii) * ji as f64 * tau.powi(ji - 1);
+    let delta_3: f64 = delta_3(rho);
+    if cfg!(feature = "nightly") {
+        let (delta, tau): ([f64; 39], [f64; 39]) = (
+            std::array::from_fn(|x| delta_3.powi(REGION_3_COEFFS_II[x + 1])),
+            std::array::from_fn(|x| tau.powi(REGION_3_COEFFS_JI[x + 1] - 1)),
+        );
+
+        let ni = Simd::<f64, 64>::load_or_default(&REGION_3_COEFFS_NI[1..40]);
+        let ji = (Simd::<i32, 64>::load_or_default(&REGION_3_COEFFS_JI[1..40])).cast::<f64>();
+        let delta = Simd::<f64, 64>::load_or_default(&delta);
+        let tau = Simd::<f64, 64>::load_or_default(&tau);
+
+        (ni * ji * delta * tau).reduce_sum()
+    } else {
+        let mut sum: f64 = 0.0_f64;
+        for x in 1..REGION_3_COEFFS_II.len() {
+            let ii = REGION_3_COEFFS_II[x];
+            let ji = REGION_3_COEFFS_JI[x];
+            let ni = REGION_3_COEFFS_NI[x];
+            sum += ni * delta_3.powi(ii) * ji as f64 * tau.powi(ji - 1);
+        }
+        sum
     }
-    sum
 }
 
 /// Returns the region-3 phi_tau_tau
@@ -1848,15 +2408,29 @@ fn phi_tau_3(rho: f64, t: f64) -> f64 {
 /// Pressure is assumed to be in Pa
 fn phi_tau_tau_3(rho: f64, t: f64) -> f64 {
     let tau: f64 = tau_3(t);
-    let delta: f64 = delta_3(rho);
-    let mut sum: f64 = 0.0_f64;
-    for x in 1..REGION_3_COEFFS_II.len() {
-        let ii = REGION_3_COEFFS_II[x];
-        let ji = REGION_3_COEFFS_JI[x];
-        let ni = REGION_3_COEFFS_NI[x];
-        sum += ni * delta.powi(ii) * (ji * (ji - 1)) as f64 * tau.powi(ji - 2);
+    let delta_3: f64 = delta_3(rho);
+    if cfg!(feature = "nightly") {
+        let (delta, tau): ([f64; 39], [f64; 39]) = (
+            std::array::from_fn(|x| delta_3.powi(REGION_3_COEFFS_II[x + 1])),
+            std::array::from_fn(|x| tau.powi(REGION_3_COEFFS_JI[x + 1] - 2)),
+        );
+
+        let ni = Simd::<f64, 64>::load_or_default(&REGION_3_COEFFS_NI[1..40]);
+        let ji = (Simd::<i32, 64>::load_or_default(&REGION_3_COEFFS_JI[1..40])).cast::<f64>();
+        let delta = Simd::<f64, 64>::load_or_default(&delta);
+        let tau = Simd::<f64, 64>::load_or_default(&tau);
+
+        (ni * ji * (ji - f64x64::splat(1.0)) * delta * tau).reduce_sum()
+    } else {
+        let mut sum: f64 = 0.0_f64;
+        for x in 1..REGION_3_COEFFS_II.len() {
+            let ii = REGION_3_COEFFS_II[x];
+            let ji = REGION_3_COEFFS_JI[x];
+            let ni = REGION_3_COEFFS_NI[x];
+            sum += ni * delta_3.powi(ii) * (ji * (ji - 1)) as f64 * tau.powi(ji - 2);
+        }
+        sum
     }
-    sum
 }
 
 /// Returns the region-3 phi_delta_tau
@@ -1864,15 +2438,30 @@ fn phi_tau_tau_3(rho: f64, t: f64) -> f64 {
 /// Pressure is assumed to be in Pa
 fn phi_delta_tau_3(rho: f64, t: f64) -> f64 {
     let tau: f64 = tau_3(t);
-    let delta: f64 = delta_3(rho);
-    let mut sum: f64 = 0.0_f64;
-    for x in 1..REGION_3_COEFFS_II.len() {
-        let ii = REGION_3_COEFFS_II[x];
-        let ji = REGION_3_COEFFS_JI[x];
-        let ni = REGION_3_COEFFS_NI[x];
-        sum += ni * delta.powi(ii - 1) * (ii * ji) as f64 * tau.powi(ji - 1);
+    let delta_3: f64 = delta_3(rho);
+    if cfg!(feature = "nightly") {
+        let (delta, tau): ([f64; 39], [f64; 39]) = (
+            std::array::from_fn(|x| delta_3.powi(REGION_3_COEFFS_II[x + 1] - 1)),
+            std::array::from_fn(|x| tau.powi(REGION_3_COEFFS_JI[x + 1] - 1)),
+        );
+
+        let ni = Simd::<f64, 64>::load_or_default(&REGION_3_COEFFS_NI[1..40]);
+        let ii = (Simd::<i32, 64>::load_or_default(&REGION_3_COEFFS_II[1..40])).cast::<f64>();
+        let ji = (Simd::<i32, 64>::load_or_default(&REGION_3_COEFFS_JI[1..40])).cast::<f64>();
+        let delta = Simd::<f64, 64>::load_or_default(&delta);
+        let tau = Simd::<f64, 64>::load_or_default(&tau);
+
+        (ni * ji * ii * delta * tau).reduce_sum()
+    } else {
+        let mut sum: f64 = 0.0_f64;
+        for x in 1..REGION_3_COEFFS_II.len() {
+            let ii = REGION_3_COEFFS_II[x];
+            let ji = REGION_3_COEFFS_JI[x];
+            let ni = REGION_3_COEFFS_NI[x];
+            sum += ni * delta_3.powi(ii - 1) * (ii * ji) as f64 * tau.powi(ji - 1);
+        }
+        sum
     }
-    sum
 }
 
 /// Returns the pressure given t and rho

--- a/src/iapws97/region_5.rs
+++ b/src/iapws97/region_5.rs
@@ -186,6 +186,7 @@ fn gamma_pi_tau_5_res(t: f64, p: f64) -> f64 {
 /// Returns the region-5 specific volume
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
+#[inline]
 pub(crate) fn v_tp_5(t: f64, p: f64) -> f64 {
     ((constants::_R * 1000.0) * t / p) * pi_5(p) * (gamma_pi_5_ideal(t, p) + gamma_pi_5_res(t, p))
 }
@@ -193,6 +194,7 @@ pub(crate) fn v_tp_5(t: f64, p: f64) -> f64 {
 /// Returns the region-5 enthalpy
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
+#[inline]
 pub(crate) fn h_tp_5(t: f64, p: f64) -> f64 {
     constants::_R * t * tau_5(t) * (gamma_tau_5_ideal(t, p) + gamma_tau_5_res(t, p))
 }
@@ -200,6 +202,7 @@ pub(crate) fn h_tp_5(t: f64, p: f64) -> f64 {
 /// Returns the region-5 internal energy
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
+#[inline]
 pub(crate) fn u_tp_5(t: f64, p: f64) -> f64 {
     let tau: f64 = tau_5(t);
     let pi: f64 = pi_5(p);
@@ -212,6 +215,7 @@ pub(crate) fn u_tp_5(t: f64, p: f64) -> f64 {
 /// Returns the region-5 entropy
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
+#[inline]
 pub(crate) fn s_tp_5(t: f64, p: f64) -> f64 {
     let tau = tau_5(t);
     constants::_R
@@ -229,6 +233,7 @@ pub(crate) fn cp_tp_5(t: f64, p: f64) -> f64 {
 /// Returns the region-5 isochoric specific heat
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
+#[inline]
 pub(crate) fn cv_tp_5(t: f64, p: f64) -> f64 {
     let pi: f64 = pi_5(p);
     cp_tp_5(t, p)
@@ -241,6 +246,7 @@ pub(crate) fn cv_tp_5(t: f64, p: f64) -> f64 {
 /// Returns the region-5 sound velocity
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
+#[inline]
 pub(crate) fn w_tp_5(t: f64, p: f64) -> f64 {
     let tau: f64 = tau_5(t);
     let pi: f64 = pi_5(p);

--- a/src/iapws97/region_5.rs
+++ b/src/iapws97/region_5.rs
@@ -1,21 +1,27 @@
 use crate::iapws97::constants;
 
-const REGION_5_COEFFS_RES: [[f64; 3]; 6] = [
-    [1.0, 1.0, 0.15736404855259e-2],
-    [1.0, 2.0, 0.90153761673944e-3],
-    [1.0, 3.0, -0.50270077677648e-2],
-    [2.0, 3.0, 0.22440037409485e-5],
-    [2.0, 9.0, -0.41163275453471e-5],
-    [3.0, 7.0, 0.37919454822955e-7],
+const REGION_5_COEFFS_RES_II: [i32; 6] = [1, 1, 1, 2, 2, 3];
+
+const REGION_5_COEFFS_RES_JI: [i32; 6] = [1, 2, 3, 3, 9, 7];
+
+const REGION_5_COEFFS_RES_NI: [f64; 6] = [
+    0.15736404855259e-2,
+    0.90153761673944e-3,
+    -0.50270077677648e-2,
+    0.22440037409485e-5,
+    -0.41163275453471e-5,
+    0.37919454822955e-7,
 ];
 
-const REGION_5_COEFFS_IDEAL: [[f64; 2]; 6] = [
-    [0.0, -0.13179983674201e2],
-    [1.0, 0.68540841634434e1],
-    [-3.0, -0.24805148933466e-1],
-    [-2.0, 0.36901534980333],
-    [-1.0, -0.31161318213925e1],
-    [2.0, -0.32961626538917],
+const REGION_5_COEFFS_IDEAL_JI: [i32; 6] = [0, 1, -3, -2, -1, 2];
+
+const REGION_5_COEFFS_IDEAL_NI: [f64; 6] = [
+    -0.13179983674201e2,
+    0.68540841634434e1,
+    -0.24805148933466e-1,
+    0.36901534980333,
+    -0.31161318213925e1,
+    -0.32961626538917,
 ];
 
 // ================    Region 5 ===================
@@ -25,7 +31,7 @@ const REGION_5_COEFFS_IDEAL: [[f64; 2]; 6] = [
 /// Pressure is assumed to be in Pa
 #[inline(always)]
 fn tau_5(t: f64) -> f64 {
-    1000.0 / t
+    1000.0_f64 / t
 }
 
 /// Returns the region-5 pi
@@ -40,28 +46,28 @@ fn pi_5(p: f64) -> f64 {
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
 fn gamma_5_ideal(t: f64, p: f64) -> f64 {
-    let pi: f64 = pi_5(p);
-    let mut sum: f64 = 0.0;
+    let pi = pi_5(p);
     let tau: f64 = tau_5(t);
-    for coefficient in REGION_5_COEFFS_IDEAL {
-        let ji: i32 = coefficient[0] as i32;
-        let ni: f64 = coefficient[1];
+    let mut sum = 0.0_f64;
+    for x in 0..REGION_5_COEFFS_IDEAL_JI.len() {
+        let ji = REGION_5_COEFFS_IDEAL_JI[x];
+        let ni = REGION_5_COEFFS_IDEAL_NI[x];
         sum += ni * tau.powi(ji);
     }
-    pi.ln() + sum
+    sum + pi.ln()
 }
 
 /// Returns the region-2 residual gamma
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
 fn gamma_5_res(t: f64, p: f64) -> f64 {
-    let pi: f64 = pi_5(p);
-    let mut sum: f64 = 0.0;
-    let tau: f64 = tau_5(t);
-    for coefficient in REGION_5_COEFFS_RES {
-        let ii: i32 = coefficient[0] as i32;
-        let ji: i32 = coefficient[1] as i32;
-        let ni: f64 = coefficient[2];
+    let pi = pi_5(p);
+    let tau = tau_5(t);
+    let mut sum = 0.0_f64;
+    for x in 0..REGION_5_COEFFS_RES_II.len() {
+        let ii = REGION_5_COEFFS_RES_II[x];
+        let ji = REGION_5_COEFFS_RES_JI[x];
+        let ni = REGION_5_COEFFS_RES_NI[x];
         sum += ni * pi.powi(ii) * tau.powi(ji);
     }
     sum
@@ -71,12 +77,12 @@ fn gamma_5_res(t: f64, p: f64) -> f64 {
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
 fn gamma_tau_5_ideal(t: f64, _: f64) -> f64 {
-    let mut sum: f64 = 0.0;
-    let tau: f64 = tau_5(t);
-    for coefficient in REGION_5_COEFFS_IDEAL {
-        let ji: f64 = coefficient[0];
-        let ni: f64 = coefficient[1];
-        sum += ni * ji * tau.powi(ji as i32 - 1);
+    let tau = tau_5(t);
+    let mut sum = 0.0_f64;
+    for x in 0..REGION_5_COEFFS_IDEAL_JI.len() {
+        let ji = REGION_5_COEFFS_IDEAL_JI[x];
+        let ni = REGION_5_COEFFS_IDEAL_NI[x];
+        sum += ni * ji as f64 * tau.powi(ji - 1);
     }
     sum
 }
@@ -85,12 +91,12 @@ fn gamma_tau_5_ideal(t: f64, _: f64) -> f64 {
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
 fn gamma_tau_tau_5_ideal(t: f64, _: f64) -> f64 {
-    let mut sum: f64 = 0.0;
-    let tau: f64 = tau_5(t);
-    for coefficient in REGION_5_COEFFS_IDEAL {
-        let ji: f64 = coefficient[0];
-        let ni: f64 = coefficient[1];
-        sum += ni * ji * (ji - 1.0) * tau.powi(ji as i32 - 2);
+    let tau = tau_5(t);
+    let mut sum = 0.0_f64;
+    for x in 0..REGION_5_COEFFS_IDEAL_JI.len() {
+        let ji = REGION_5_COEFFS_IDEAL_JI[x];
+        let ni = REGION_5_COEFFS_IDEAL_NI[x];
+        sum += ni * (ji * (ji - 1)) as f64 * tau.powi(ji - 2);
     }
     sum
 }
@@ -100,21 +106,21 @@ fn gamma_tau_tau_5_ideal(t: f64, _: f64) -> f64 {
 /// Pressure is assumed to be in Pa
 #[inline(always)]
 fn gamma_pi_5_ideal(_: f64, p: f64) -> f64 {
-    1.0 / pi_5(p)
+    1.0_f64 / pi_5(p)
 }
 
 /// Returns the region-5 residual gamma_tau
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
 fn gamma_tau_5_res(t: f64, p: f64) -> f64 {
+    let tau = tau_5(t);
+    let pi = pi_5(p);
     let mut sum: f64 = 0.0;
-    let tau: f64 = tau_5(t);
-    let pi: f64 = pi_5(p);
-    for coefficient in REGION_5_COEFFS_RES {
-        let ii: i32 = coefficient[0] as i32;
-        let ji: f64 = coefficient[1];
-        let ni: f64 = coefficient[2];
-        sum += ni * pi.powi(ii) * ji * tau.powi(ji as i32 - 1);
+    for x in 0..REGION_5_COEFFS_RES_II.len() {
+        let ii = REGION_5_COEFFS_RES_II[x];
+        let ji = REGION_5_COEFFS_RES_JI[x];
+        let ni = REGION_5_COEFFS_RES_NI[x];
+        sum += ni * pi.powi(ii) * ji as f64 * tau.powi(ji - 1);
     }
     sum
 }
@@ -123,14 +129,14 @@ fn gamma_tau_5_res(t: f64, p: f64) -> f64 {
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
 fn gamma_tau_tau_5_res(t: f64, p: f64) -> f64 {
-    let mut sum: f64 = 0.0;
-    let tau: f64 = tau_5(t);
-    let pi: f64 = pi_5(p);
-    for coefficient in REGION_5_COEFFS_RES {
-        let ii: i32 = coefficient[0] as i32;
-        let ji: f64 = coefficient[1];
-        let ni: f64 = coefficient[2];
-        sum += ni * pi.powi(ii) * ji * (ji - 1.0) * tau.powi(ji as i32 - 2);
+    let tau = tau_5(t);
+    let pi = pi_5(p);
+    let mut sum: f64 = 0.0_f64;
+    for x in 0..REGION_5_COEFFS_RES_II.len() {
+        let ii = REGION_5_COEFFS_RES_II[x];
+        let ji = REGION_5_COEFFS_RES_JI[x];
+        let ni = REGION_5_COEFFS_RES_NI[x];
+        sum += ni * pi.powi(ii) * (ji * (ji - 1)) as f64 * tau.powi(ji - 2);
     }
     sum
 }
@@ -139,14 +145,14 @@ fn gamma_tau_tau_5_res(t: f64, p: f64) -> f64 {
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
 fn gamma_pi_5_res(t: f64, p: f64) -> f64 {
-    let mut sum: f64 = 0.0;
-    let tau: f64 = tau_5(t);
-    let pi: f64 = pi_5(p);
-    for coefficient in REGION_5_COEFFS_RES {
-        let ii: f64 = coefficient[0];
-        let ji: i32 = coefficient[1] as i32;
-        let ni: f64 = coefficient[2];
-        sum += ni * ii * pi.powi(ii as i32 - 1) * tau.powi(ji);
+    let tau = tau_5(t);
+    let pi = pi_5(p);
+    let mut sum = 0.0_f64;
+    for x in 0..REGION_5_COEFFS_RES_II.len() {
+        let ii = REGION_5_COEFFS_RES_II[x];
+        let ji = REGION_5_COEFFS_RES_JI[x];
+        let ni = REGION_5_COEFFS_RES_NI[x];
+        sum += ni * ii as f64 * pi.powi(ii - 1) * tau.powi(ji);
     }
     sum
 }
@@ -155,14 +161,14 @@ fn gamma_pi_5_res(t: f64, p: f64) -> f64 {
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
 fn gamma_pi_pi_5_res(t: f64, p: f64) -> f64 {
-    let mut sum: f64 = 0.0;
-    let tau: f64 = tau_5(t);
-    let pi: f64 = pi_5(p);
-    for coefficient in REGION_5_COEFFS_RES {
-        let ii: f64 = coefficient[0];
-        let ji: i32 = coefficient[1] as i32;
-        let ni: f64 = coefficient[2];
-        sum += ni * ii * (ii - 1.0) * pi.powi(ii as i32 - 2) * tau.powi(ji);
+    let tau = tau_5(t);
+    let pi = pi_5(p);
+    let mut sum = 0.0_f64;
+    for x in 0..REGION_5_COEFFS_RES_II.len() {
+        let ii = REGION_5_COEFFS_RES_II[x];
+        let ji = REGION_5_COEFFS_RES_JI[x];
+        let ni = REGION_5_COEFFS_RES_NI[x];
+        sum += ni * (ii * (ii - 1)) as f64 * pi.powi(ii - 2) * tau.powi(ji);
     }
     sum
 }
@@ -171,14 +177,14 @@ fn gamma_pi_pi_5_res(t: f64, p: f64) -> f64 {
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
 fn gamma_pi_tau_5_res(t: f64, p: f64) -> f64 {
-    let mut sum: f64 = 0.0;
-    let tau: f64 = tau_5(t);
-    let pi: f64 = pi_5(p);
-    for coefficient in REGION_5_COEFFS_RES {
-        let ii: f64 = coefficient[0];
-        let ji: f64 = coefficient[1];
-        let ni: f64 = coefficient[2];
-        sum += ni * ii * pi.powi(ii as i32 - 1) * ji * tau.powi(ji as i32 - 1);
+    let tau = tau_5(t);
+    let pi = pi_5(p);
+    let mut sum = 0.0_f64;
+    for x in 0..REGION_5_COEFFS_RES_II.len() {
+        let ii = REGION_5_COEFFS_RES_II[x];
+        let ji = REGION_5_COEFFS_RES_JI[x];
+        let ni = REGION_5_COEFFS_RES_NI[x];
+        sum += ni * ii as f64 * pi.powi(ii - 1) * ji as f64 * tau.powi(ji - 1);
     }
     sum
 }
@@ -204,8 +210,8 @@ pub(crate) fn h_tp_5(t: f64, p: f64) -> f64 {
 /// Pressure is assumed to be in Pa
 #[inline]
 pub(crate) fn u_tp_5(t: f64, p: f64) -> f64 {
-    let tau: f64 = tau_5(t);
-    let pi: f64 = pi_5(p);
+    let tau = tau_5(t);
+    let pi = pi_5(p);
     constants::_R
         * t
         * (tau * (gamma_tau_5_ideal(t, p) + gamma_tau_5_res(t, p))
@@ -226,6 +232,7 @@ pub(crate) fn s_tp_5(t: f64, p: f64) -> f64 {
 /// Returns the region-5 isobaric specific heat
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
+#[inline]
 pub(crate) fn cp_tp_5(t: f64, p: f64) -> f64 {
     -constants::_R * tau_5(t).powi(2) * (gamma_tau_tau_5_ideal(t, p) + gamma_tau_tau_5_res(t, p))
 }
@@ -235,7 +242,7 @@ pub(crate) fn cp_tp_5(t: f64, p: f64) -> f64 {
 /// Pressure is assumed to be in Pa
 #[inline]
 pub(crate) fn cv_tp_5(t: f64, p: f64) -> f64 {
-    let pi: f64 = pi_5(p);
+    let pi = pi_5(p);
     cp_tp_5(t, p)
         - constants::_R
             * (((1.0 + pi * gamma_pi_5_res(t, p) - tau_5(t) * pi * gamma_pi_tau_5_res(t, p))
@@ -248,13 +255,13 @@ pub(crate) fn cv_tp_5(t: f64, p: f64) -> f64 {
 /// Pressure is assumed to be in Pa
 #[inline]
 pub(crate) fn w_tp_5(t: f64, p: f64) -> f64 {
-    let tau: f64 = tau_5(t);
-    let pi: f64 = pi_5(p);
-    let num: f64 =
-        1.0 + 2.0 * pi * gamma_pi_5_res(t, p) + pi.powi(2) * gamma_pi_5_res(t, p).powi(2);
+    let tau = tau_5(t);
+    let pi = pi_5(p);
+    let num =
+        1.0_f64 + 2.0_f64 * pi * gamma_pi_5_res(t, p) + pi.powi(2) * gamma_pi_5_res(t, p).powi(2);
     let subnum: f64 =
-        (1.0 + pi * gamma_pi_5_res(t, p) - tau * pi * gamma_pi_tau_5_res(t, p)).powi(2);
+        (1.0_f64 + pi * gamma_pi_5_res(t, p) - tau * pi * gamma_pi_tau_5_res(t, p)).powi(2);
     let subden: f64 = tau.powi(2) * (gamma_tau_tau_5_ideal(t, p) + gamma_tau_tau_5_res(t, p));
     let den: f64 = 1.0 - pi.powi(2) * gamma_pi_pi_5_res(t, p) + subnum / subden;
-    ((constants::_R * 1000.0 * t) * num / den).sqrt()
+    ((constants::_R * 1000.0_f64 * t) * num / den).sqrt()
 }

--- a/src/iapws97/region_5.rs
+++ b/src/iapws97/region_5.rs
@@ -23,6 +23,7 @@ const REGION_5_COEFFS_IDEAL: [[f64; 2]; 6] = [
 /// Returns the region-5 tau
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
+#[inline(always)]
 fn tau_5(t: f64) -> f64 {
     1000.0 / t
 }
@@ -30,6 +31,7 @@ fn tau_5(t: f64) -> f64 {
 /// Returns the region-5 pi
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
+#[inline(always)]
 fn pi_5(p: f64) -> f64 {
     p / 1e6
 }
@@ -96,6 +98,7 @@ fn gamma_tau_tau_5_ideal(t: f64, _: f64) -> f64 {
 /// Returns the region-5 ideal gamma_pi
 /// Temperature is assumed to be in K
 /// Pressure is assumed to be in Pa
+#[inline(always)]
 fn gamma_pi_5_ideal(_: f64, p: f64) -> f64 {
     1.0 / pi_5(p)
 }


### PR DESCRIPTION
[Codspeed](https://codspeed.io/) allows for regression testing in a sanitized and standardized environment. It allows speed improvements to be directly compared. You may need to create your own account (it is free and easy with a github account) to perform it. If you want to see the how it would look, feel free to look at mine for this [library](https://codspeed.io/jurskidl/rusteam). You can compare runs via the 'runs' tab and selecting the ones you want to compare. You can also set minimum thresholds that it will identify as a change (mine is set to 10% which appears to sometimes allow noise in this library since it the times are so small).

The no_std functionality right now is relatively simply implemented by pulling the intrinsics library directly. This is what the std library uses, but further upstream. This may be able to be improved, but this is an initial implementation with an immeasurable impact on performance.